### PR TITLE
Add put option support and outline follow-up tasks

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -1,0 +1,43 @@
+# Next Tasks
+
+Below is the prioritized queue of work items to continue generalizing the simulator. Check each item off as it is completed. Use the **View task** links to jump directly to detailed notes for that task.
+
+- [ ] Task 1: Data provider abstraction ([View task](#task-1-data-provider-abstraction))
+- [ ] Task 2: Live volatility integration ([View task](#task-2-live-volatility-integration))
+- [ ] Task 3: CLI/UX polish ([View task](#task-3-cliux-polish))
+
+---
+
+## Task 1: Data provider abstraction
+- **Objective:** Introduce a pluggable data-access layer that can load spot prices and option chains from Schwab or a mock source for offline testing.
+- **Key steps:**
+  - Define an interface (e.g., `DataProvider`) responsible for fetching spot, option quotes, and contract metadata.
+  - Implement a Schwab-backed provider that authenticates, requests the option chain, and maps results to the simulator schema.
+  - Provide an in-memory/mock provider for unit tests and demos.
+  - Add configuration hooks so the simulator selects a provider at runtime.
+
+[View task](#next-tasks)
+
+---
+
+## Task 2: Live volatility integration
+- **Objective:** Replace fixed IV inputs with real-time implied volatility from the option chain, while retaining overrides for scenario testing.
+- **Key steps:**
+  - Extend the configuration to accept per-contract IV sourced from the data provider.
+  - Add fallbacks when IV is missing, including historical or user-specified values.
+  - Surface controls to bias or stress-test volatility (e.g., +/- percentage adjustments).
+  - Ensure simulation reporting logs the IV source and adjustments used.
+
+[View task](#next-tasks)
+
+---
+
+## Task 3: CLI/UX polish
+- **Objective:** Streamline the CLI so users can select contracts interactively and review scenario outputs across multiple tickers.
+- **Key steps:**
+  - Add commands/subcommands to list available expirations/strikes pulled from the data provider.
+  - Provide presets for common strategies (single-leg, spreads) while keeping manual overrides.
+  - Improve output formatting (tables/plots) and allow exporting CSV/JSON summaries.
+  - Document CLI usage examples that cover both calls and puts.
+
+[View task](#next-tasks)

--- a/gld_mc/config.py
+++ b/gld_mc/config.py
@@ -3,6 +3,14 @@ from dataclasses import dataclass
 
 @dataclass
 class SimConfig:
+    """Simulation inputs for a single option contract scenario."""
+
+    # Instrument metadata
+    symbol: str                  = "GLD"
+    option_type: str             = "call"      # "call" or "put"
+    expiration: str | None       = None        # ISO date string when available
+    contract_multiplier: int     = 100
+
     # Market & contract
     spot: float                  = 364.38
     strike: float                = 370.0

--- a/gld_mc/pricing.py
+++ b/gld_mc/pricing.py
@@ -28,3 +28,22 @@ def black_scholes_call(S, K, T, r, sigma):
     # intrinsic if effectively expired
     price = np.where(T <= tiny, np.maximum(S - K, 0.0), price)
     return price
+
+
+def black_scholes_put(S, K, T, r, sigma):
+    """Vectorized Black–Scholes put price."""
+    S = np.asarray(S, dtype=float)
+    T = np.asarray(T, dtype=float)
+
+    tiny = 1e-12
+    T_safe = np.maximum(T, tiny)
+
+    d1 = (np.log(S / K) + (r + 0.5 * sigma * sigma) * T_safe) / (sigma * np.sqrt(T_safe))
+    d2 = d1 - sigma * np.sqrt(T_safe)
+
+    Nd1 = norm_cdf(-d1)
+    Nd2 = norm_cdf(-d2)
+
+    price = (K * np.exp(-r * T_safe) * Nd2) - (S * Nd1)
+    price = np.where(T <= tiny, np.maximum(K - S, 0.0), price)
+    return price

--- a/gld_mc/sim.py
+++ b/gld_mc/sim.py
@@ -2,16 +2,26 @@ from __future__ import annotations
 import math
 import numpy as np
 import pandas as pd
-from dataclasses import asdict
 
 from .config import SimConfig
-from .pricing import black_scholes_call
+from .pricing import black_scholes_call, black_scholes_put
 
 def simulate(cfg: SimConfig):
     """
-    Run a single Monte-Carlo simulation for a long call with target/stop rules.
+    Run a single Monte-Carlo simulation for a long call or put with target/stop rules.
     Returns: (summary_df, details_df)
     """
+    option_type = cfg.option_type.lower()
+    if option_type not in {"call", "put"}:
+        raise NotImplementedError(f"option_type='{cfg.option_type}' is not yet supported")
+
+    if option_type == "call":
+        price_fn = black_scholes_call
+        intrinsic_fn = lambda spot: max(spot - cfg.strike, 0.0)
+    else:
+        price_fn = black_scholes_put
+        intrinsic_fn = lambda spot: max(cfg.strike - spot, 0.0)
+
     rng = np.random.default_rng(cfg.seed)
 
     trading_days = max(int(round(cfg.dte_calendar * (cfg.annual_trading_days / 365.0))), 1)
@@ -36,7 +46,7 @@ def simulate(cfg: SimConfig):
     exit_price  = np.zeros(cfg.num_trials, dtype=float)
     exit_reason = np.array(["hold"] * cfg.num_trials, dtype=object)
 
-    entry_cash = cfg.entry_price * 100.0 + cfg.commission_per_side
+    entry_cash = cfg.entry_price * cfg.contract_multiplier + cfg.commission_per_side
 
     for i in range(cfg.num_trials):
         sigma = sigmas[i]
@@ -48,8 +58,8 @@ def simulate(cfg: SimConfig):
             S = S * math.exp((mu - 0.5 * sigma * sigma) * dt + sigma * math.sqrt(dt) * z)
 
             T_rem = Ts[t]
-            C = black_scholes_call(S, cfg.strike, T_rem, cfg.risk_free_rate, sigma)
-            exit_cash = C * 100.0 - cfg.commission_per_side
+            option_price = price_fn(S, cfg.strike, T_rem, cfg.risk_free_rate, sigma)
+            exit_cash = option_price * cfg.contract_multiplier - cfg.commission_per_side
             pnl = exit_cash - entry_cash
 
             days_left = trading_days - (t + 1)
@@ -59,40 +69,46 @@ def simulate(cfg: SimConfig):
                 hit_target[i]  = True
                 hit_day[i]     = t + 1
                 final_pl[i]    = pnl
-                exit_price[i]  = C
+                exit_price[i]  = option_price
                 exit_reason[i] = "target"
                 exited = True
                 break
 
-            if can_exit and C <= cfg.stop_option_price:
+            if can_exit and option_price <= cfg.stop_option_price:
                 hit_target[i]  = False
                 hit_day[i]     = t + 1
                 final_pl[i]    = pnl
-                exit_price[i]  = C
+                exit_price[i]  = option_price
                 exit_reason[i] = "stop"
                 exited = True
                 break
 
         if not exited:
-            C_exp = max(S - cfg.strike, 0.0)
-            exit_cash = C_exp * 100.0 - cfg.commission_per_side
+            intrinsic = intrinsic_fn(S)
+            exit_cash = intrinsic * cfg.contract_multiplier - cfg.commission_per_side
             final_pl[i]    = exit_cash - entry_cash
-            exit_price[i]  = C_exp
-            exit_reason[i] = "expiry_ITM" if C_exp > 0 else "expiry_OTM"
+            exit_price[i]  = intrinsic
+            exit_reason[i] = "expiry_ITM" if intrinsic > 0 else "expiry_OTM"
 
     # Summary stats
     prob_hit = hit_target.mean()
     med_day  = float(np.median(hit_day[hit_day > 0])) if np.any(hit_day > 0) else float("nan")
     p5, p25, p50, p75, p95 = np.percentile(final_pl, [5, 25, 50, 75, 95])
 
+    option_label = cfg.option_type.lower()
+    option_display = {"call": "Call", "put": "Put"}.get(option_label, cfg.option_type)
+    expiration_display = cfg.expiration or "n/a"
+
     summary = pd.DataFrame({
         "Metric": [
-            "Trials", "Trading Days", "IV Mode", "IV Fixed", "IV Range",
-            "Drift Mode", "Drift (annual)", "Entry Price", "Strike", "Target Profit",
+            "Symbol", "Option Type", "Expiration", "Contract Multiplier", "Trials",
+            "Trading Days", "IV Mode", "IV Fixed", "IV Range", "Drift Mode",
+            "Drift (annual)", "Entry Price", "Strike", "Target Profit",
             "Stop (option price)", "P(hit target before expiry)", "Median day to hit target",
             "Mean Final P&L", "P&L p5", "P&L p25", "P&L p50", "P&L p75", "P&L p95"
         ],
         "Value": [
+            cfg.symbol, option_display, expiration_display, cfg.contract_multiplier,
             f"{cfg.num_trials:,}", trading_days, cfg.iv_mode, cfg.iv_fixed,
             f"{cfg.iv_min}–{cfg.iv_max}", cfg.mu_mode, cfg.mu_custom,
             f"${cfg.entry_price:.2f}", cfg.strike, f"${cfg.target_profit:.0f}",


### PR DESCRIPTION
## Summary
- extend the pricing module and Monte Carlo engine so scenarios can simulate long calls or long puts
- clarify configuration defaults to reflect the new option-type support and keep pricing/expiry logic aligned for both legs
- add a task list describing the next milestones for data integration, volatility sourcing, and CLI polish

## Testing
- python -m compileall gld_mc


------
https://chatgpt.com/codex/tasks/task_e_68e45a0dc6588331a6d75f2b23a42288