### PR TITLE
Add market data provider framework and UI streaming

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -1,0 +1,44 @@
+# Next Tasks
+
+Below is the prioritized queue of work items to continue generalizing the simulator. Check each item off as it is completed. Use the **View task** links to jump directly to detailed notes for that task.
+
+- [x] Task 1: Data provider abstraction ([View task](#task-1-data-provider-abstraction))
+- [ ] Task 2: Live volatility integration ([View task](#task-2-live-volatility-integration))
+- [ ] Task 3: CLI/UX polish ([View task](#task-3-cliux-polish))
+
+---
+
+## Task 1: Data provider abstraction
+- **Objective:** Introduce a pluggable data-access layer that can load spot prices and option chains from Schwab or a mock source for offline testing.
+- **Key steps:**
+  - Define an interface (e.g., `DataProvider`) responsible for fetching spot, option quotes, and contract metadata.
+  - Implement a Schwab-backed provider that authenticates, requests the option chain, and maps results to the simulator schema.
+  - Provide an in-memory/mock provider for unit tests and demos.
+  - Add configuration hooks so the simulator selects a provider at runtime.
+- **Status:** ✅ Framework in place with `MarketDataProvider` protocol, Schwab adapter skeleton, polling stream handle, mock generator, and UI integration that streams the chain into a live table. Next up: wire the real Schwab client implementation and credential flow.
+
+[View task](#next-tasks)
+
+---
+
+## Task 2: Live volatility integration
+- **Objective:** Replace fixed IV inputs with real-time implied volatility from the option chain, while retaining overrides for scenario testing.
+- **Key steps:**
+  - Extend the configuration to accept per-contract IV sourced from the data provider.
+  - Add fallbacks when IV is missing, including historical or user-specified values.
+  - Surface controls to bias or stress-test volatility (e.g., +/- percentage adjustments).
+  - Ensure simulation reporting logs the IV source and adjustments used.
+
+[View task](#next-tasks)
+
+---
+
+## Task 3: CLI/UX polish
+- **Objective:** Streamline the CLI so users can select contracts interactively and review scenario outputs across multiple tickers.
+- **Key steps:**
+  - Add commands/subcommands to list available expirations/strikes pulled from the data provider.
+  - Provide presets for common strategies (single-leg, spreads) while keeping manual overrides.
+  - Improve output formatting (tables/plots) and allow exporting CSV/JSON summaries.
+  - Document CLI usage examples that cover both calls and puts.
+
+[View task](#next-tasks)

--- a/gld_mc/cli.py
+++ b/gld_mc/cli.py
@@ -9,8 +9,18 @@ from .config import SimConfig
 from .sim import simulate
 from .plotting import plot_results
 
+_OPTION_CODE = {"call": "C", "put": "P"}
+
+
+def _option_code(option_type: str) -> str:
+    return _OPTION_CODE.get(option_type.lower(), option_type.upper())
+
 def parse_args():
-    p = argparse.ArgumentParser(description="GLD Long Call Monte-Carlo (modular).")
+    p = argparse.ArgumentParser(description="Options Monte-Carlo simulator (single contract).")
+    p.add_argument("--symbol", default="GLD", help="underlying symbol")
+    p.add_argument("--option-type", choices=["call", "put"], default="call", help="option contract type")
+    p.add_argument("--expiration", default="", help="expiration date (YYYY-MM-DD)")
+    p.add_argument("--multiplier", type=int, default=100, help="contract multiplier (shares per contract)")
     # Primary knobs
     p.add_argument("--spot", type=float, default=364.38)
     p.add_argument("--strike", type=float, default=370.0)
@@ -61,7 +71,13 @@ def run_one(cfg: SimConfig, out_dir: str, tag: str):
 def main():
     args = parse_args()
 
+    expiration = args.expiration.strip() or None
+
     base = SimConfig(
+        symbol=args.symbol,
+        option_type=args.option_type,
+        expiration=expiration,
+        contract_multiplier=args.multiplier,
         spot=args.spot,
         strike=args.strike,
         dte_calendar=args.dte,
@@ -87,7 +103,7 @@ def main():
         rows = []
         for k in strikes:
             cfg = SimConfig(**{**asdict(base), "strike": k})
-            tag = args.tag or f"GLD_{int(cfg.strike)}C_{cfg.dte_calendar}DTE_{cfg.iv_mode}_tr{cfg.num_trials}"
+            tag = args.tag or f"{cfg.symbol}_{int(cfg.strike)}{_option_code(cfg.option_type)}_{cfg.dte_calendar}DTE_{cfg.iv_mode}_tr{cfg.num_trials}"
             s = run_one(cfg, out_dir, tag)
             s["Scenario"] = tag
             rows.append(s)
@@ -96,7 +112,7 @@ def main():
         comp.to_csv(comp_path, index=False)
         print(f"[Saved] {comp_path}")
     else:
-        tag = args.tag or f"GLD_{int(base.strike)}C_{base.dte_calendar}DTE_{base.iv_mode}_tr{base.num_trials}"
+        tag = args.tag or f"{base.symbol}_{int(base.strike)}{_option_code(base.option_type)}_{base.dte_calendar}DTE_{base.iv_mode}_tr{base.num_trials}"
         run_one(base, out_dir, tag)
 
 if __name__ == "__main__":

--- a/gld_mc/config.py
+++ b/gld_mc/config.py
@@ -1,8 +1,31 @@
 from __future__ import annotations
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional
+
+
+@dataclass
+class DataProviderConfig:
+    """Runtime settings for the market data provider."""
+
+    backend: str = "mock"
+    poll_interval: float = 5.0
+    params: Dict[str, Any] = field(default_factory=dict)
+    auto_start_stream: bool = True
+    default_symbol: Optional[str] = "GLD"
+    default_option_type: str = "call"
+    default_expiration: Optional[str] = None
 
 @dataclass
 class SimConfig:
+    """Simulation inputs for a single option contract scenario."""
+
+    # Instrument metadata
+    symbol: str                  = "GLD"
+    option_type: str             = "call"      # "call" or "put"
+    expiration: str | None       = None        # ISO date string when available
+    contract_multiplier: int     = 100
+    data_provider: DataProviderConfig = field(default_factory=DataProviderConfig)
+
     # Market & contract
     spot: float                  = 364.38
     strike: float                = 370.0

--- a/gld_mc/data_provider.py
+++ b/gld_mc/data_provider.py
@@ -1,0 +1,309 @@
+from __future__ import annotations
+
+import threading
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, Optional, Protocol
+
+import numpy as np
+import pandas as pd
+
+from .config import DataProviderConfig
+
+
+class QuoteStreamHandle:
+    """Handle that manages a background polling loop."""
+
+    def __init__(
+        self,
+        fetch_fn: Callable[[], pd.DataFrame],
+        on_update: Callable[[pd.DataFrame], None],
+        on_error: Optional[Callable[[Exception], None]] = None,
+        poll_interval: float = 5.0,
+    ) -> None:
+        self._fetch_fn = fetch_fn
+        self._on_update = on_update
+        self._on_error = on_error
+        self._interval = poll_interval
+        self._stop = threading.Event()
+        self._thread = threading.Thread(target=self._run, daemon=True)
+
+    def start(self) -> None:
+        self._thread.start()
+
+    def stop(self) -> None:
+        self._stop.set()
+        if self._thread.is_alive():
+            self._thread.join(timeout=1.0)
+
+    def _run(self) -> None:
+        while not self._stop.is_set():
+            try:
+                df = self._fetch_fn()
+                self._on_update(df)
+            except Exception as exc:  # noqa: BLE001 - surface provider errors to UI
+                if self._on_error is not None:
+                    self._on_error(exc)
+            finally:
+                # Wait with cancellation support
+                if self._interval <= 0:
+                    break
+                self._stop.wait(self._interval)
+
+
+class MarketDataProvider(Protocol):
+    """Common interface for spot/option chain retrieval."""
+
+    def get_spot(self, symbol: str) -> float:
+        ...
+
+    def get_option_chain(
+        self,
+        symbol: str,
+        *,
+        expiration: Optional[str] = None,
+        option_type: Optional[str] = None,
+        params: Optional[Dict[str, Any]] = None,
+    ) -> pd.DataFrame:
+        ...
+
+    def stream_option_chain(
+        self,
+        symbol: str,
+        on_update: Callable[[pd.DataFrame], None],
+        *,
+        expiration: Optional[str] = None,
+        option_type: Optional[str] = None,
+        params: Optional[Dict[str, Any]] = None,
+        poll_interval: float = 5.0,
+        on_error: Optional[Callable[[Exception], None]] = None,
+    ) -> QuoteStreamHandle:
+        ...
+
+
+class MockDataProvider:
+    """In-memory provider that fabricates a realistic option chain."""
+
+    def __init__(self, seed: Optional[int] = None) -> None:
+        self._rng = np.random.default_rng(seed)
+
+    def get_spot(self, symbol: str) -> float:
+        base = 100 + (hash(symbol) % 50)
+        return float(base + self._rng.normal(0, 1.5))
+
+    def get_option_chain(
+        self,
+        symbol: str,
+        *,
+        expiration: Optional[str] = None,
+        option_type: Optional[str] = None,
+        params: Optional[Dict[str, Any]] = None,
+    ) -> pd.DataFrame:
+        params = params or {}
+        option_type = (option_type or "call").lower()
+        spot = params.get("spot") or self.get_spot(symbol)
+
+        strikes = params.get("strikes")
+        if not strikes:
+            strikes = np.linspace(spot * 0.8, spot * 1.2, num=11)
+
+        expiration = expiration or params.get("expiration") or "2024-12-20"
+        dte = params.get("dte", 30)
+
+        rows = []
+        for strike in strikes:
+            skew = 0.15 + 0.05 * (strike / spot - 1.0)
+            iv = abs(skew) + 0.18 + self._rng.normal(0, 0.01)
+            bid = max(0.05, max(spot - strike if option_type == "call" else strike - spot, 0.0))
+            noise = self._rng.normal(0, 0.1)
+            ask = max(bid + 0.05, bid + abs(noise))
+            mid = (bid + ask) / 2
+            rows.append(
+                {
+                    "symbol": symbol.upper(),
+                    "expiration": expiration,
+                    "dte": dte,
+                    "option_type": option_type,
+                    "strike": round(float(strike), 2),
+                    "bid": round(float(bid), 2),
+                    "ask": round(float(ask), 2),
+                    "mark": round(float(mid), 2),
+                    "last": round(float(mid + self._rng.normal(0, 0.05)), 2),
+                    "iv": round(float(iv), 4),
+                    "delta": round(float(self._rng.normal(0.45, 0.05)), 4),
+                    "gamma": round(float(self._rng.normal(0.01, 0.002)), 5),
+                    "theta": round(float(self._rng.normal(-0.03, 0.01)), 4),
+                    "vega": round(float(self._rng.normal(0.12, 0.02)), 4),
+                    "rho": round(float(self._rng.normal(0.05, 0.01)), 4),
+                    "volume": int(abs(self._rng.normal(250, 120))),
+                    "open_interest": int(abs(self._rng.normal(1200, 320))),
+                }
+            )
+
+        df = pd.DataFrame(rows)
+        return df.sort_values("strike").reset_index(drop=True)
+
+    def stream_option_chain(
+        self,
+        symbol: str,
+        on_update: Callable[[pd.DataFrame], None],
+        *,
+        expiration: Optional[str] = None,
+        option_type: Optional[str] = None,
+        params: Optional[Dict[str, Any]] = None,
+        poll_interval: float = 5.0,
+        on_error: Optional[Callable[[Exception], None]] = None,
+    ) -> QuoteStreamHandle:
+        def fetch() -> pd.DataFrame:
+            return self.get_option_chain(
+                symbol,
+                expiration=expiration,
+                option_type=option_type,
+                params=params,
+            )
+
+        handle = QuoteStreamHandle(fetch, on_update, on_error, poll_interval)
+        handle.start()
+        return handle
+
+
+class SchwabClient(Protocol):
+    """Minimal protocol expected from a Schwab API client."""
+
+    def get_quote(self, symbol: str) -> Dict[str, Any]:
+        ...
+
+    def get_option_chain(self, symbol: str, **params: Any) -> Dict[str, Any]:
+        ...
+
+
+@dataclass
+class SchwabDataProvider:
+    """Adapter that converts Schwab API responses into simulator-friendly frames."""
+
+    client: SchwabClient
+
+    def get_spot(self, symbol: str) -> float:
+        quote = self.client.get_quote(symbol)
+        for key in ("mark", "lastPrice", "lastTrade", "close", "regularMarketLastPrice"):
+            if key in quote and quote[key] is not None:
+                return float(quote[key])
+        raise KeyError(f"Quote response missing price fields for {symbol}: {quote}")
+
+    def get_option_chain(
+        self,
+        symbol: str,
+        *,
+        expiration: Optional[str] = None,
+        option_type: Optional[str] = None,
+        params: Optional[Dict[str, Any]] = None,
+    ) -> pd.DataFrame:
+        params = params.copy() if params else {}
+        if expiration:
+            params.setdefault("expirationDate", expiration)
+        if option_type:
+            params.setdefault("contractType", option_type.upper())
+
+        raw = self.client.get_option_chain(symbol, **params)
+        return self._parse_option_chain(raw)
+
+    def stream_option_chain(
+        self,
+        symbol: str,
+        on_update: Callable[[pd.DataFrame], None],
+        *,
+        expiration: Optional[str] = None,
+        option_type: Optional[str] = None,
+        params: Optional[Dict[str, Any]] = None,
+        poll_interval: float = 5.0,
+        on_error: Optional[Callable[[Exception], None]] = None,
+    ) -> QuoteStreamHandle:
+        def fetch() -> pd.DataFrame:
+            return self.get_option_chain(
+                symbol,
+                expiration=expiration,
+                option_type=option_type,
+                params=params,
+            )
+
+        handle = QuoteStreamHandle(fetch, on_update, on_error, poll_interval)
+        handle.start()
+        return handle
+
+    @staticmethod
+    def _parse_option_chain(raw: Dict[str, Any]) -> pd.DataFrame:
+        """Flatten Schwab's nested option chain payload into a DataFrame."""
+
+        if not raw:
+            return pd.DataFrame(columns=[
+                "symbol",
+                "expiration",
+                "dte",
+                "option_type",
+                "strike",
+                "bid",
+                "ask",
+                "mark",
+                "last",
+                "iv",
+                "delta",
+                "gamma",
+                "theta",
+                "vega",
+                "rho",
+                "volume",
+                "open_interest",
+            ])
+
+        rows = []
+        expirations = raw.get("callExpDateMap", {}) | raw.get("putExpDateMap", {})
+        for expiration, strikes in expirations.items():
+            # Schwab expiration keys look like "2024-12-20:30" (date:DTE)
+            exp_parts = expiration.split(":")
+            exp_date = exp_parts[0]
+            dte = int(exp_parts[1]) if len(exp_parts) > 1 and exp_parts[1].isdigit() else None
+            for strike, contracts in strikes.items():
+                for contract in contracts:
+                    option_type = contract.get("putCall", "").lower()
+                    rows.append(
+                        {
+                            "symbol": contract.get("symbol", raw.get("symbol")),
+                            "expiration": exp_date,
+                            "dte": dte,
+                            "option_type": option_type,
+                            "strike": float(contract.get("strikePrice", strike)),
+                            "bid": contract.get("bid", 0.0),
+                            "ask": contract.get("ask", 0.0),
+                            "mark": contract.get("mark", 0.0),
+                            "last": contract.get("last", 0.0),
+                            "iv": contract.get("volatility", 0.0) / 100.0,
+                            "delta": contract.get("delta", 0.0),
+                            "gamma": contract.get("gamma", 0.0),
+                            "theta": contract.get("theta", 0.0),
+                            "vega": contract.get("vega", 0.0),
+                            "rho": contract.get("rho", 0.0),
+                            "volume": contract.get("totalVolume", 0),
+                            "open_interest": contract.get("openInterest", 0),
+                        }
+                    )
+
+        return pd.DataFrame(rows)
+
+
+def create_data_provider(
+    config: DataProviderConfig,
+    *,
+    schwab_client: Optional[SchwabClient] = None,
+) -> MarketDataProvider:
+    backend = config.backend.lower()
+    if backend == "mock":
+        seed = None
+        if config.params:
+            seed = config.params.get("seed")
+        return MockDataProvider(seed=seed)
+    if backend == "schwab":
+        if schwab_client is None:
+            raise ValueError("schwab_client must be provided when backend='schwab'")
+        return SchwabDataProvider(client=schwab_client)
+
+    raise ValueError(f"Unknown data provider backend: {config.backend}")
+

--- a/gld_mc/pricing.py
+++ b/gld_mc/pricing.py
@@ -28,3 +28,22 @@ def black_scholes_call(S, K, T, r, sigma):
     # intrinsic if effectively expired
     price = np.where(T <= tiny, np.maximum(S - K, 0.0), price)
     return price
+
+
+def black_scholes_put(S, K, T, r, sigma):
+    """Vectorized Black–Scholes put price."""
+    S = np.asarray(S, dtype=float)
+    T = np.asarray(T, dtype=float)
+
+    tiny = 1e-12
+    T_safe = np.maximum(T, tiny)
+
+    d1 = (np.log(S / K) + (r + 0.5 * sigma * sigma) * T_safe) / (sigma * np.sqrt(T_safe))
+    d2 = d1 - sigma * np.sqrt(T_safe)
+
+    Nd1 = norm_cdf(-d1)
+    Nd2 = norm_cdf(-d2)
+
+    price = (K * np.exp(-r * T_safe) * Nd2) - (S * Nd1)
+    price = np.where(T <= tiny, np.maximum(K - S, 0.0), price)
+    return price

--- a/gld_mc/sim.py
+++ b/gld_mc/sim.py
@@ -2,16 +2,26 @@ from __future__ import annotations
 import math
 import numpy as np
 import pandas as pd
-from dataclasses import asdict
 
 from .config import SimConfig
-from .pricing import black_scholes_call
+from .pricing import black_scholes_call, black_scholes_put
 
 def simulate(cfg: SimConfig):
     """
-    Run a single Monte-Carlo simulation for a long call with target/stop rules.
+    Run a single Monte-Carlo simulation for a long call or put with target/stop rules.
     Returns: (summary_df, details_df)
     """
+    option_type = cfg.option_type.lower()
+    if option_type not in {"call", "put"}:
+        raise NotImplementedError(f"option_type='{cfg.option_type}' is not yet supported")
+
+    if option_type == "call":
+        price_fn = black_scholes_call
+        intrinsic_fn = lambda spot: max(spot - cfg.strike, 0.0)
+    else:
+        price_fn = black_scholes_put
+        intrinsic_fn = lambda spot: max(cfg.strike - spot, 0.0)
+
     rng = np.random.default_rng(cfg.seed)
 
     trading_days = max(int(round(cfg.dte_calendar * (cfg.annual_trading_days / 365.0))), 1)
@@ -36,7 +46,7 @@ def simulate(cfg: SimConfig):
     exit_price  = np.zeros(cfg.num_trials, dtype=float)
     exit_reason = np.array(["hold"] * cfg.num_trials, dtype=object)
 
-    entry_cash = cfg.entry_price * 100.0 + cfg.commission_per_side
+    entry_cash = cfg.entry_price * cfg.contract_multiplier + cfg.commission_per_side
 
     for i in range(cfg.num_trials):
         sigma = sigmas[i]
@@ -48,8 +58,8 @@ def simulate(cfg: SimConfig):
             S = S * math.exp((mu - 0.5 * sigma * sigma) * dt + sigma * math.sqrt(dt) * z)
 
             T_rem = Ts[t]
-            C = black_scholes_call(S, cfg.strike, T_rem, cfg.risk_free_rate, sigma)
-            exit_cash = C * 100.0 - cfg.commission_per_side
+            option_price = price_fn(S, cfg.strike, T_rem, cfg.risk_free_rate, sigma)
+            exit_cash = option_price * cfg.contract_multiplier - cfg.commission_per_side
             pnl = exit_cash - entry_cash
 
             days_left = trading_days - (t + 1)
@@ -59,40 +69,46 @@ def simulate(cfg: SimConfig):
                 hit_target[i]  = True
                 hit_day[i]     = t + 1
                 final_pl[i]    = pnl
-                exit_price[i]  = C
+                exit_price[i]  = option_price
                 exit_reason[i] = "target"
                 exited = True
                 break
 
-            if can_exit and C <= cfg.stop_option_price:
+            if can_exit and option_price <= cfg.stop_option_price:
                 hit_target[i]  = False
                 hit_day[i]     = t + 1
                 final_pl[i]    = pnl
-                exit_price[i]  = C
+                exit_price[i]  = option_price
                 exit_reason[i] = "stop"
                 exited = True
                 break
 
         if not exited:
-            C_exp = max(S - cfg.strike, 0.0)
-            exit_cash = C_exp * 100.0 - cfg.commission_per_side
+            intrinsic = intrinsic_fn(S)
+            exit_cash = intrinsic * cfg.contract_multiplier - cfg.commission_per_side
             final_pl[i]    = exit_cash - entry_cash
-            exit_price[i]  = C_exp
-            exit_reason[i] = "expiry_ITM" if C_exp > 0 else "expiry_OTM"
+            exit_price[i]  = intrinsic
+            exit_reason[i] = "expiry_ITM" if intrinsic > 0 else "expiry_OTM"
 
     # Summary stats
     prob_hit = hit_target.mean()
     med_day  = float(np.median(hit_day[hit_day > 0])) if np.any(hit_day > 0) else float("nan")
     p5, p25, p50, p75, p95 = np.percentile(final_pl, [5, 25, 50, 75, 95])
 
+    option_label = cfg.option_type.lower()
+    option_display = {"call": "Call", "put": "Put"}.get(option_label, cfg.option_type)
+    expiration_display = cfg.expiration or "n/a"
+
     summary = pd.DataFrame({
         "Metric": [
-            "Trials", "Trading Days", "IV Mode", "IV Fixed", "IV Range",
-            "Drift Mode", "Drift (annual)", "Entry Price", "Strike", "Target Profit",
+            "Symbol", "Option Type", "Expiration", "Contract Multiplier", "Trials",
+            "Trading Days", "IV Mode", "IV Fixed", "IV Range", "Drift Mode",
+            "Drift (annual)", "Entry Price", "Strike", "Target Profit",
             "Stop (option price)", "P(hit target before expiry)", "Median day to hit target",
             "Mean Final P&L", "P&L p5", "P&L p25", "P&L p50", "P&L p75", "P&L p95"
         ],
         "Value": [
+            cfg.symbol, option_display, expiration_display, cfg.contract_multiplier,
             f"{cfg.num_trials:,}", trading_days, cfg.iv_mode, cfg.iv_fixed,
             f"{cfg.iv_min}–{cfg.iv_max}", cfg.mu_mode, cfg.mu_custom,
             f"${cfg.entry_price:.2f}", cfg.strike, f"${cfg.target_profit:.0f}",

--- a/gld_mc/ui.py
+++ b/gld_mc/ui.py
@@ -6,21 +6,87 @@ import time
 import tkinter as tk
 from tkinter import ttk, messagebox
 
-import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt
 from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg
 
-from .config import SimConfig
+from .config import DataProviderConfig, SimConfig
+from .data_provider import QuoteStreamHandle, create_data_provider
 from .sim import simulate
 
 PAD = 10
 
+
+class OptionsChainViewer(ttk.Frame):
+    """Treeview widget for displaying an option chain DataFrame."""
+
+    columns = (
+        "strike",
+        "option_type",
+        "bid",
+        "ask",
+        "mark",
+        "last",
+        "iv",
+        "delta",
+        "gamma",
+        "theta",
+        "vega",
+        "rho",
+        "volume",
+        "open_interest",
+    )
+
+    def __init__(self, parent):
+        super().__init__(parent, padding=PAD)
+
+        self._last_update = tk.StringVar(value="")
+
+        header = ttk.Frame(self)
+        header.pack(fill="x", pady=(0, PAD))
+        ttk.Label(header, text="Live Option Chain", font=("TkDefaultFont", 11, "bold")).pack(side="left")
+        ttk.Label(header, textvariable=self._last_update).pack(side="right")
+
+        columns = ("strike", "option_type", "bid", "ask", "mark", "last", "iv",
+                   "delta", "gamma", "theta", "vega", "rho", "volume", "open_interest")
+        self.columns = columns
+
+        self.tree = ttk.Treeview(self, columns=self.columns, show="headings", height=12)
+        for col in self.columns:
+            self.tree.heading(col, text=col.replace("_", " ").title())
+            width = 90 if col not in {"strike", "option_type"} else 80
+            self.tree.column(col, width=width, anchor="center")
+
+        vsb = ttk.Scrollbar(self, orient="vertical", command=self.tree.yview)
+        self.tree.configure(yscrollcommand=vsb.set)
+
+        self.tree.pack(side="left", fill="both", expand=True)
+        vsb.pack(side="right", fill="y")
+
+    def update_from_dataframe(self, df: pd.DataFrame, timestamp: str | None = None) -> None:
+        self.tree.delete(*self.tree.get_children())
+        if df.empty:
+            self._last_update.set("No data")
+            return
+
+        for _, row in df.iterrows():
+            values = [row.get(col, "") for col in self.columns]
+            self.tree.insert("", "end", values=values)
+
+        if timestamp:
+            self._last_update.set(f"Updated {timestamp}")
+        else:
+            self._last_update.set("Updated")
+
 class SimUI(tk.Tk):
     def __init__(self):
         super().__init__()
-        self.title("GLD Long Call Monte Carlo")
-        self.geometry("940x780")
+        self.title("Options Monte Carlo Simulator")
+        self.geometry("1050x820")
+        self.data_settings = DataProviderConfig()
+        self.data_provider = create_data_provider(self.data_settings)
+        self._chain_handle: QuoteStreamHandle | None = None
+        self._latest_chain: pd.DataFrame | None = None
         self._build_notebook()
 
     def _build_notebook(self):
@@ -43,6 +109,22 @@ class SimUI(tk.Tk):
     def _build_single_tab(self, root):
         root = ttk.Frame(root, padding=PAD)
         root.pack(fill="both", expand=True)
+
+        default_symbol = self.data_settings.default_symbol or "GLD"
+
+        # --- Instrument ---
+        isec = ttk.LabelFrame(root, text="Instrument", padding=PAD)
+        isec.pack(fill="x", expand=False, pady=(0, PAD))
+
+        self.var_symbol = tk.StringVar(value=default_symbol)
+        self.var_option_type = tk.StringVar(value=self.data_settings.default_option_type)
+        self.var_expiration = tk.StringVar(value=self.data_settings.default_expiration or "")
+        self.var_multiplier = tk.IntVar(value=100)
+
+        self._add_labeled_entry(isec, "Symbol", self.var_symbol, 0, 0)
+        self._add_combo(isec, "Option type", self.var_option_type, ["call", "put"], 0, 1)
+        self._add_labeled_entry(isec, "Expiration (YYYY-MM-DD)", self.var_expiration, 1, 0)
+        self._add_labeled_entry(isec, "Contract multiplier", self.var_multiplier, 1, 1)
 
         # --- Market & Contract
         msec = ttk.LabelFrame(root, text="Market & Contract", padding=PAD)
@@ -110,15 +192,29 @@ class SimUI(tk.Tk):
         self._add_combo(dsec, "μ mode", self.var_mu_mode, ["risk_neutral", "custom"], 0, 0)
         self._add_labeled_entry(dsec, "μ custom (annual)", self.var_mu_custom, 0, 1)
 
+        # --- Live Market Data
+        mdat = ttk.LabelFrame(root, text="Live Market Data", padding=PAD)
+        mdat.pack(fill="both", expand=True, pady=(0, PAD))
+
+        controls = ttk.Frame(mdat)
+        controls.pack(fill="x", pady=(0, PAD))
+        ttk.Button(controls, text="Start Stream", command=self._start_chain_stream).pack(side="left")
+        ttk.Button(controls, text="Stop Stream", command=self._stop_chain_stream).pack(side="left", padx=(PAD, 0))
+        ttk.Button(controls, text="Copy Last Chain", command=self._copy_chain_to_clipboard).pack(side="right")
+
+        self.chain_view = OptionsChainViewer(mdat)
+        self.chain_view.pack(fill="both", expand=True)
+
         # --- Buttons
         btn_row = ttk.Frame(root, padding=(0, PAD))
         btn_row.pack(fill="x", expand=False)
         ttk.Button(btn_row, text="Run Simulation", command=self._run_single).pack(side="left")
         ttk.Button(btn_row, text="Quit", command=self.destroy).pack(side="right")
 
-        ttk.Label(root, text="Charts appear in a separate Results window. CSVs saved to ./out/").pack(
-            side="bottom", anchor="w"
-        )
+        ttk.Label(root, text="Charts appear in a separate Results window. CSVs saved to ./out/").pack(side="bottom", anchor="w")
+
+        if self.data_settings.auto_start_stream:
+            self.after(200, self._start_chain_stream)
 
     # ======= BATCH TAB =======
     def _build_batch_tab(self, root):
@@ -126,6 +222,20 @@ class SimUI(tk.Tk):
         root.pack(fill="both", expand=True)
 
         # Reuse same-style blocks but with separate variables (so Single and Batch are independent)
+
+        # --- Instrument ---
+        b_inst = ttk.LabelFrame(root, text="Instrument", padding=PAD)
+        b_inst.pack(fill="x", expand=False, pady=(0, PAD))
+
+        self.b_symbol = tk.StringVar(value=self.data_settings.default_symbol or "GLD")
+        self.b_option_type = tk.StringVar(value=self.data_settings.default_option_type)
+        self.b_expiration = tk.StringVar(value=self.data_settings.default_expiration or "")
+        self.b_multiplier = tk.IntVar(value=100)
+
+        self._add_labeled_entry(b_inst, "Symbol", self.b_symbol, 0, 0)
+        self._add_combo(b_inst, "Option type", self.b_option_type, ["call", "put"], 0, 1)
+        self._add_labeled_entry(b_inst, "Expiration (YYYY-MM-DD)", self.b_expiration, 1, 0)
+        self._add_labeled_entry(b_inst, "Contract multiplier", self.b_multiplier, 1, 1)
 
         # --- Market & Contract
         msec = ttk.LabelFrame(root, text="Market & Contract (shared across strikes)", padding=PAD)
@@ -211,6 +321,65 @@ class SimUI(tk.Tk):
             side="bottom", anchor="w"
         )
 
+    # ======= Market data =======
+    def _start_chain_stream(self) -> None:
+        symbol = self.var_symbol.get().strip().upper() or (self.data_settings.default_symbol or "GLD")
+        expiration = self.var_expiration.get().strip() or None
+        option_type = self.var_option_type.get().strip().lower()
+        option_filter = option_type if option_type in {"call", "put"} else None
+
+        params = dict(self.data_settings.params) if self.data_settings.params else {}
+
+        self._stop_chain_stream()
+
+        try:
+            self._chain_handle = self.data_provider.stream_option_chain(
+                symbol=symbol,
+                expiration=expiration,
+                option_type=option_filter,
+                params=params,
+                poll_interval=self.data_settings.poll_interval,
+                on_update=self._handle_chain_update,
+                on_error=self._handle_chain_error,
+            )
+        except Exception as exc:  # noqa: BLE001 - present provider errors to the user
+            self._chain_handle = None
+            messagebox.showerror("Market data", f"Failed to start option chain stream:\n{exc}")
+
+    def _stop_chain_stream(self) -> None:
+        if self._chain_handle is not None:
+            self._chain_handle.stop()
+            self._chain_handle = None
+
+    def _handle_chain_update(self, df: pd.DataFrame) -> None:
+        timestamp = time.strftime("%H:%M:%S")
+        self._latest_chain = df.copy()
+
+        def _update() -> None:
+            self.chain_view.update_from_dataframe(self._latest_chain, timestamp)
+
+        self.after(0, _update)
+
+    def _handle_chain_error(self, exc: Exception) -> None:
+        def _show() -> None:
+            messagebox.showerror("Market data stream", str(exc))
+
+        self.after(0, _show)
+        self._stop_chain_stream()
+
+    def _copy_chain_to_clipboard(self) -> None:
+        if self._latest_chain is None or self._latest_chain.empty:
+            messagebox.showinfo("Copy option chain", "No option chain data available yet.")
+            return
+
+        try:
+            csv_text = self._latest_chain.to_csv(index=False)
+            self.clipboard_clear()
+            self.clipboard_append(csv_text)
+            messagebox.showinfo("Copy option chain", "Latest option chain copied to clipboard (CSV format).")
+        except Exception as exc:  # noqa: BLE001
+            messagebox.showerror("Copy option chain", f"Failed to copy option chain:\n{exc}")
+
     # ======= Helpers =======
     def _add_labeled_entry(self, parent, text, var, row, col):
         frm = ttk.Frame(parent)
@@ -224,8 +393,20 @@ class SimUI(tk.Tk):
         ttk.Label(frm, text=label).pack(side="top", anchor="w")
         ttk.Combobox(frm, textvariable=var, values=values, width=18, state="readonly").pack(side="top", anchor="w")
 
+    @staticmethod
+    def _option_code(option_type: str) -> str:
+        return {"call": "C", "put": "P"}.get(option_type.lower(), option_type.upper())
+
     def _collect_config_single(self) -> SimConfig:
+        symbol = self.var_symbol.get().strip().upper() or "GLD"
+        expiration = self.var_expiration.get().strip() or None
+        option_type = self.var_option_type.get().strip().lower()
+
         return SimConfig(
+            symbol=symbol,
+            option_type=option_type,
+            expiration=expiration,
+            contract_multiplier=self.var_multiplier.get(),
             spot=self.var_spot.get(),
             strike=self.var_strike.get(),
             dte_calendar=self.var_dte.get(),
@@ -244,11 +425,20 @@ class SimUI(tk.Tk):
             avoid_final_days=self.var_avoid.get(),
             mu_mode=self.var_mu_mode.get(),
             mu_custom=self.var_mu_custom.get(),
+            data_provider=self.data_settings,
         )
 
     def _collect_config_batch_common(self) -> SimConfig:
         # shared settings across all strikes in the batch
+        symbol = self.b_symbol.get().strip().upper() or "GLD"
+        expiration = self.b_expiration.get().strip() or None
+        option_type = self.b_option_type.get().strip().lower()
+
         return SimConfig(
+            symbol=symbol,
+            option_type=option_type,
+            expiration=expiration,
+            contract_multiplier=self.b_multiplier.get(),
             spot=self.b_spot.get(),
             dte_calendar=self.b_dte.get(),
             annual_trading_days=self.b_annual.get(),
@@ -266,6 +456,7 @@ class SimUI(tk.Tk):
             avoid_final_days=self.b_avoid.get(),
             mu_mode=self.b_mu_mode.get(),
             mu_custom=self.b_mu_custom.get(),
+            data_provider=self.data_settings,
         )
 
     # ======= Actions =======
@@ -279,7 +470,8 @@ class SimUI(tk.Tk):
         summary, details = simulate(cfg)
         os.makedirs("out", exist_ok=True)
         stamp = time.strftime("%Y%m%d_%H%M%S")
-        tag = f"GLD_{int(cfg.strike)}C_{cfg.dte_calendar}DTE_tr{cfg.num_trials}_{stamp}"
+        code = self._option_code(cfg.option_type)
+        tag = f"{cfg.symbol}_{int(cfg.strike)}{code}_{cfg.dte_calendar}DTE_tr{cfg.num_trials}_{stamp}"
         summary.to_csv(os.path.join("out", f"{tag}_summary.csv"), index=False)
         details.to_csv(os.path.join("out", f"{tag}_details.csv"), index=False)
 
@@ -298,27 +490,38 @@ class SimUI(tk.Tk):
         base = self._collect_config_batch_common()
         os.makedirs("out", exist_ok=True)
 
-        results = []  # list of (strike, summary_df, details_df)
+        results = []  # list of result dicts
         stamp = time.strftime("%Y%m%d_%H%M%S")
 
         for k in strikes:
             cfg = SimConfig(**{**base.__dict__, "strike": k})
             summary, details = simulate(cfg)
 
-            tag = f"GLD_{int(k)}C_{cfg.dte_calendar}DTE_tr{cfg.num_trials}_{stamp}"
+            code = self._option_code(cfg.option_type)
+            tag = f"{cfg.symbol}_{int(k)}{code}_{cfg.dte_calendar}DTE_tr{cfg.num_trials}_{stamp}"
             summary.to_csv(os.path.join("out", f"{tag}_summary.csv"), index=False)
             details.to_csv(os.path.join("out", f"{tag}_details.csv"), index=False)
 
             s_copy = summary.copy()
             s_copy.insert(0, "Strike", k)
-            results.append((k, s_copy, details))
+            s_copy.insert(1, "Option Type", cfg.option_type)
+            results.append({
+                "strike": k,
+                "option_type": cfg.option_type,
+                "summary": s_copy,
+                "details": details,
+            })
 
         # Save combined batch summary
-        combo = pd.concat([r[1] for r in results], ignore_index=True)
+        combo = pd.concat([r["summary"] for r in results], ignore_index=True)
         combo.to_csv(os.path.join("out", f"batch_summary_{stamp}.csv"), index=False)
 
         # Show batch results window (overlaid charts)
         self._show_results_window_batch(results, stamp)
+
+    def destroy(self):
+        self._stop_chain_stream()
+        super().destroy()
 
     # ======= Result windows =======
     def _show_results_window_single(self, details: pd.DataFrame, tag: str):
@@ -357,10 +560,7 @@ class SimUI(tk.Tk):
         ttk.Button(win, text="Close", command=win.destroy).pack(side="bottom", pady=PAD)
 
     def _show_results_window_batch(self, results, stamp_tag: str):
-        """
-        results: list of (strike, summary_df, details_df)
-        Draw overlaid histograms with distinct colors + legend.
-        """
+        """Draw overlaid histograms with distinct colors + legend."""
         win = tk.Toplevel(self)
         win.title(f"Batch Results — {stamp_tag}")
         win.geometry("1200x780")
@@ -379,13 +579,16 @@ class SimUI(tk.Tk):
         fig1 = plt.Figure(figsize=(6.8, 5.0), dpi=100)
         ax1 = fig1.add_subplot(111)
 
-        for idx, (k, _summary, details) in enumerate(results):
+        for idx, result in enumerate(results):
+            k = result["strike"]
+            option_type = result["option_type"]
+            details = result["details"]
             color = palette[idx % len(palette)]
             ax1.hist(
                 details["final_pl"],
                 bins=70,
                 alpha=0.35,
-                label=f"{int(k)}C",
+                label=f"{int(k)}{self._option_code(option_type)}",
                 color=color
             )
 
@@ -393,7 +596,7 @@ class SimUI(tk.Tk):
         ax1.set_xlabel("P&L per contract ($)")
         ax1.set_ylabel("Frequency")
         ax1.grid(True, alpha=0.3)
-        ax1.legend(title="Strike")
+        ax1.legend(title="Strike/Type")
 
         canvas1 = FigureCanvasTkAgg(fig1, master=container)
         canvas1.draw()
@@ -403,14 +606,17 @@ class SimUI(tk.Tk):
         fig2 = plt.Figure(figsize=(6.8, 5.0), dpi=100)
         ax2 = fig2.add_subplot(111)
 
-        for idx, (k, _summary, details) in enumerate(results):
+        for idx, result in enumerate(results):
+            k = result["strike"]
+            option_type = result["option_type"]
+            details = result["details"]
             color = palette[idx % len(palette)]
             if details["hit_target"].any():
                 ax2.hist(
                     details.loc[details["hit_target"], "hit_day"],
                     bins=range(1, 60),
                     alpha=0.45,
-                    label=f"{int(k)}C",
+                    label=f"{int(k)}{self._option_code(option_type)}",
                     color=color
                 )
 
@@ -418,7 +624,7 @@ class SimUI(tk.Tk):
         ax2.set_xlabel("Trading day of exit")
         ax2.set_ylabel("Count")
         ax2.grid(True, alpha=0.3)
-        ax2.legend(title="Strike")
+        ax2.legend(title="Strike/Type")
 
         canvas2 = FigureCanvasTkAgg(fig2, master=container)
         canvas2.draw()


### PR DESCRIPTION
## Summary
- introduce a configurable market data layer with a mock provider, Schwab adapter skeleton, and polling stream handle
- extend the desktop UI with symbol/option controls plus a live option-chain table fed by the provider and clipboard export
- update the CLI option-type choices and mark Task 1 as complete in the task tracker

## Testing
- python -m compileall gld_mc

------
https://chatgpt.com/codex/tasks/task_e_68e45a0dc6588331a6d75f2b23a42288