### PR TITLE
Refactor chain viewer and source simulation inputs from live data

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,81 @@
-# options
+# Options Monte Carlo Simulator
+
+Interactive Monte Carlo pricing toolkit for single-leg option trades. The project now includes a pluggable
+market-data layer with live Schwab integration and a Tkinter desktop UI.
+
+## Features
+
+- Simulate long calls or puts with configurable exits, drift, and volatility models.
+- Stream a live option chain into the UI, preview contracts, and push selections directly into the
+  simulation form.
+- Swap between the bundled mock market feed and a real Schwab connection without modifying the core code.
+
+## Configuring the Schwab backend
+
+1. **Install dependencies**
+
+   ```bash
+   pip install requests cryptography
+   ```
+
+2. **Provide Schwab OAuth credentials**
+
+   Set the following environment variables (replace with your Schwab app metadata):
+
+   ```bash
+   export SCHWAB_CLIENT_ID="cKMzVrV2jbAdnWpmGgfsTBTrnxPZ4wo2"
+   export SCHWAB_CLIENT_SECRET="UGKViwdPN2AGnLYS"
+   export SCHWAB_REDIRECT_URI="https://127.0.0.1:5000/callback"
+   export SCHWAB_TOKEN_PASSPHRASE="choose-a-strong-passphrase"
+   ```
+
+   Alternatively, populate these values directly on `DataProviderConfig.schwab.oauth`. The passphrase is
+   used to encrypt the cached token bundle on disk (default location: `~/.schwab/tokens.dat`).
+
+3. **Run the one-time authorization flow**
+
+   Schwab issues both an access token and a refresh token during the OAuth code exchange. The refresh token
+   is required to automatically obtain new access tokens when the short-lived access token expires.
+
+   ```bash
+   python -m gld_mc.schwab
+   ```
+
+   Follow the printed instructions: open the authorization URL, complete the broker login, copy the `code`
+   query parameter from the redirected URL, and paste it back into the prompt. Successful completion stores
+   the encrypted refresh/ access token bundle locally.
+
+4. **Enable the Schwab data provider**
+
+   Configure the simulator to use the Schwab backend, for example:
+
+   ```python
+   from gld_mc.config import DataProviderConfig, SchwabAPIConfig, SimConfig
+
+   cfg = SimConfig(
+       symbol="AAPL",
+       option_type="call",
+       data_provider=DataProviderConfig(
+           backend="schwab",
+           poll_interval=10.0,
+           schwab=SchwabAPIConfig(
+               market_data_base="https://api.schwabapi.com/marketdata/v1",
+               trader_base="https://api.schwabapi.com/trader/v1",
+           ),
+       ),
+   )
+   ```
+
+   The Tkinter UI (`python -m gld_mc.ui`) reads the same configuration. Once the chain stream is running,
+   select a row and press **Use Selected Contract** to populate the simulation inputs with the live quote.
+
+## Common questions
+
+- **Where do I find the refresh token?** — The refresh token is returned alongside the access token during
+  the OAuth code exchange performed by `python -m gld_mc.schwab`. It is stored (encrypted) in
+  `~/.schwab/tokens.dat` and refreshed automatically whenever the simulator polls the API.
+- **Can I store credentials elsewhere?** — Adjust `SchwabOAuthConfig.token_cache` to change the file
+  location. The passphrase environment variable controls the encryption key.
+- **How often can I poll?** — The default rate limiter caps requests at 120 per minute to match Schwab’s
+  published guidance. Adjust `SchwabRateLimit.max_requests_per_minute` if your entitlement differs.
+

--- a/TASKS.md
+++ b/TASKS.md
@@ -1,0 +1,63 @@
+# Next Tasks
+
+Below is the prioritized queue of work items to continue generalizing the simulator. Check each item off as it is completed. Use the **View task** links to jump directly to detailed notes for that task.
+
+- [x] Task 1: Data provider abstraction ([View task](#task-1-data-provider-abstraction))
+- [ ] Task 2: Simulation input plumbing ([View task](#task-2-simulation-input-plumbing))
+- [ ] Task 3: Live volatility integration ([View task](#task-3-live-volatility-integration))
+- [ ] Task 4: CLI/UX polish ([View task](#task-4-cliux-polish))
+
+---
+
+## Task 1: Data provider abstraction
+- **Objective:** Introduce a pluggable data-access layer that can load spot prices and option chains from Schwab or a mock source for offline testing.
+- **Key steps:**
+  - Define an interface (e.g., `DataProvider`) responsible for fetching spot, option quotes, and contract metadata.
+  - Implement a Schwab-backed provider that authenticates, requests the option chain, and maps results to the simulator schema.
+  - Provide an in-memory/mock provider for unit tests and demos.
+  - Add configuration hooks so the simulator selects a provider at runtime.
+- **Status:** ✅ Framework in place with `MarketDataProvider` protocol, a refresh-aware Schwab REST client with encrypted token storage, polling stream handle, mock generator, and UI integration that streams the chain into a live table. Complete the initial OAuth handshake (see README) to populate the encrypted cache before using the Schwab backend.
+
+[View task](#next-tasks)
+
+---
+
+## Task 2: Simulation input plumbing
+- **Objective:** Let users select a contract from the live option chain and have the simulator forms auto-populate with that contract's strike, expiration, mark price, implied volatility, and DTE.
+- **Key information needed:**
+  - Preferred UI gesture for selecting a contract (row click, double-click, or a dedicated "Use in simulation" button).
+  - Mapping between chain columns and simulation inputs (e.g., `markPrice` → entry, `bidPrice`/`askPrice` averages, which IV field to trust, multiplier handling).
+  - Fallback behavior when the chain omits a value (use manual overrides, compute DTE from expiration, prompt the user, etc.).
+  - Whether batch runs should also accept auto-populated rows or only single-run forms.
+- **Implementation steps:**
+  - Wire the `OptionsChainViewer` selection callback to capture the selected row's data.
+  - Normalize the row into a `SimConfig`-compatible payload, applying any fallbacks.
+  - Update the single-run form fields in the UI (and CLI defaults where appropriate).
+  - Record the auto-populated metadata in simulation summaries for auditability.
+- **Status:** 🚧 Pending clarification from the user on the interaction flow and fallback rules noted above.
+
+[View task](#next-tasks)
+
+---
+
+## Task 3: Live volatility integration
+- **Objective:** Replace fixed IV inputs with real-time implied volatility from the option chain, while retaining overrides for scenario testing.
+- **Key steps:**
+  - Extend the configuration to accept per-contract IV sourced from the data provider.
+  - Add fallbacks when IV is missing, including historical or user-specified values.
+  - Surface controls to bias or stress-test volatility (e.g., +/- percentage adjustments).
+  - Ensure simulation reporting logs the IV source and adjustments used.
+
+[View task](#next-tasks)
+
+---
+
+## Task 4: CLI/UX polish
+- **Objective:** Streamline the CLI so users can select contracts interactively and review scenario outputs across multiple tickers.
+- **Key steps:**
+  - Add commands/subcommands to list available expirations/strikes pulled from the data provider.
+  - Provide presets for common strategies (single-leg, spreads) while keeping manual overrides.
+  - Improve output formatting (tables/plots) and allow exporting CSV/JSON summaries.
+  - Document CLI usage examples that cover both calls and puts.
+
+[View task](#next-tasks)

--- a/gld_mc/cli.py
+++ b/gld_mc/cli.py
@@ -9,8 +9,18 @@ from .config import SimConfig
 from .sim import simulate
 from .plotting import plot_results
 
+_OPTION_CODE = {"call": "C", "put": "P"}
+
+
+def _option_code(option_type: str) -> str:
+    return _OPTION_CODE.get(option_type.lower(), option_type.upper())
+
 def parse_args():
-    p = argparse.ArgumentParser(description="GLD Long Call Monte-Carlo (modular).")
+    p = argparse.ArgumentParser(description="Options Monte-Carlo simulator (single contract).")
+    p.add_argument("--symbol", default="GLD", help="underlying symbol")
+    p.add_argument("--option-type", choices=["call", "put"], default="call", help="option contract type")
+    p.add_argument("--expiration", default="", help="expiration date (YYYY-MM-DD)")
+    p.add_argument("--multiplier", type=int, default=100, help="contract multiplier (shares per contract)")
     # Primary knobs
     p.add_argument("--spot", type=float, default=364.38)
     p.add_argument("--strike", type=float, default=370.0)
@@ -61,7 +71,13 @@ def run_one(cfg: SimConfig, out_dir: str, tag: str):
 def main():
     args = parse_args()
 
+    expiration = args.expiration.strip() or None
+
     base = SimConfig(
+        symbol=args.symbol,
+        option_type=args.option_type,
+        expiration=expiration,
+        contract_multiplier=args.multiplier,
         spot=args.spot,
         strike=args.strike,
         dte_calendar=args.dte,
@@ -87,7 +103,7 @@ def main():
         rows = []
         for k in strikes:
             cfg = SimConfig(**{**asdict(base), "strike": k})
-            tag = args.tag or f"GLD_{int(cfg.strike)}C_{cfg.dte_calendar}DTE_{cfg.iv_mode}_tr{cfg.num_trials}"
+            tag = args.tag or f"{cfg.symbol}_{int(cfg.strike)}{_option_code(cfg.option_type)}_{cfg.dte_calendar}DTE_{cfg.iv_mode}_tr{cfg.num_trials}"
             s = run_one(cfg, out_dir, tag)
             s["Scenario"] = tag
             rows.append(s)
@@ -96,7 +112,7 @@ def main():
         comp.to_csv(comp_path, index=False)
         print(f"[Saved] {comp_path}")
     else:
-        tag = args.tag or f"GLD_{int(base.strike)}C_{base.dte_calendar}DTE_{base.iv_mode}_tr{base.num_trials}"
+        tag = args.tag or f"{base.symbol}_{int(base.strike)}{_option_code(base.option_type)}_{base.dte_calendar}DTE_{base.iv_mode}_tr{base.num_trials}"
         run_one(base, out_dir, tag)
 
 if __name__ == "__main__":

--- a/gld_mc/config.py
+++ b/gld_mc/config.py
@@ -1,8 +1,68 @@
 from __future__ import annotations
-from dataclasses import dataclass
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Optional, Sequence
+
+
+@dataclass
+class DataProviderConfig:
+    """Runtime settings for the market data provider."""
+
+    backend: str = "mock"
+    poll_interval: float = 5.0
+    params: Dict[str, Any] = field(default_factory=dict)
+    auto_start_stream: bool = True
+    default_symbol: Optional[str] = "GLD"
+    default_option_type: str = "call"
+    default_expiration: Optional[str] = None
+    schwab: "SchwabAPIConfig | None" = None
+
+
+@dataclass
+class SchwabOAuthConfig:
+    """OAuth client configuration for Schwab connections."""
+
+    client_id: Optional[str] = field(default_factory=lambda: os.getenv("SCHWAB_CLIENT_ID"))
+    client_secret: Optional[str] = field(default_factory=lambda: os.getenv("SCHWAB_CLIENT_SECRET"))
+    redirect_uri: Optional[str] = field(default_factory=lambda: os.getenv("SCHWAB_REDIRECT_URI"))
+    scopes: Sequence[str] = (
+        "trade",
+        "move_money",
+        "read_account",
+        "market_data",
+    )
+    token_cache: Path = Path.home() / ".schwab" / "tokens.dat"
+    encryption_passphrase_env: str = "SCHWAB_TOKEN_PASSPHRASE"
+
+
+@dataclass
+class SchwabRateLimit:
+    """Throttle settings to respect Schwab API limits."""
+
+    max_requests_per_minute: int = 120
+
+
+@dataclass
+class SchwabAPIConfig:
+    """Complete Schwab configuration, including OAuth and endpoints."""
+
+    oauth: SchwabOAuthConfig = field(default_factory=SchwabOAuthConfig)
+    rate_limit: SchwabRateLimit = field(default_factory=SchwabRateLimit)
+    market_data_base: str = "https://api.schwabapi.com/marketdata/v1"
+    trader_base: str = "https://api.schwabapi.com/trader/v1"
 
 @dataclass
 class SimConfig:
+    """Simulation inputs for a single option contract scenario."""
+
+    # Instrument metadata
+    symbol: str                  = "GLD"
+    option_type: str             = "call"      # "call" or "put"
+    expiration: str | None       = None        # ISO date string when available
+    contract_multiplier: int     = 100
+    data_provider: DataProviderConfig = field(default_factory=DataProviderConfig)
+
     # Market & contract
     spot: float                  = 364.38
     strike: float                = 370.0

--- a/gld_mc/data_provider.py
+++ b/gld_mc/data_provider.py
@@ -1,0 +1,434 @@
+from __future__ import annotations
+
+import threading
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Callable, Dict, Optional, Protocol
+
+import numpy as np
+import pandas as pd
+
+from .config import DataProviderConfig
+
+
+def _compute_dte(
+    expiration: Optional[str],
+    quote_time_ms: Optional[float] = None,
+) -> Optional[int]:
+    """Calculate calendar days to expiration when not supplied by the API."""
+
+    if not expiration:
+        return None
+
+    try:
+        exp_date = datetime.fromisoformat(expiration[:10]).date()
+    except ValueError:
+        return None
+
+    if quote_time_ms:
+        base_dt = datetime.fromtimestamp(quote_time_ms / 1000.0, tz=timezone.utc)
+    else:
+        base_dt = datetime.now(timezone.utc)
+
+    delta = (exp_date - base_dt.date()).days
+    return max(delta, 0)
+
+
+class QuoteStreamHandle:
+    """Handle that manages a background polling loop."""
+
+    def __init__(
+        self,
+        fetch_fn: Callable[[], pd.DataFrame],
+        on_update: Callable[[pd.DataFrame], None],
+        on_error: Optional[Callable[[Exception], None]] = None,
+        poll_interval: float = 5.0,
+    ) -> None:
+        self._fetch_fn = fetch_fn
+        self._on_update = on_update
+        self._on_error = on_error
+        self._interval = poll_interval
+        self._stop = threading.Event()
+        self._thread = threading.Thread(target=self._run, daemon=True)
+
+    def start(self) -> None:
+        self._thread.start()
+
+    def stop(self) -> None:
+        self._stop.set()
+        if self._thread.is_alive():
+            self._thread.join(timeout=1.0)
+
+    def _run(self) -> None:
+        while not self._stop.is_set():
+            try:
+                df = self._fetch_fn()
+                self._on_update(df)
+            except Exception as exc:  # noqa: BLE001 - surface provider errors to UI
+                if self._on_error is not None:
+                    self._on_error(exc)
+            finally:
+                # Wait with cancellation support
+                if self._interval <= 0:
+                    break
+                self._stop.wait(self._interval)
+
+
+class MarketDataProvider(Protocol):
+    """Common interface for spot/option chain retrieval."""
+
+    def get_spot(self, symbol: str) -> float:
+        ...
+
+    def get_option_chain(
+        self,
+        symbol: str,
+        *,
+        expiration: Optional[str] = None,
+        option_type: Optional[str] = None,
+        params: Optional[Dict[str, Any]] = None,
+    ) -> pd.DataFrame:
+        ...
+
+    def stream_option_chain(
+        self,
+        symbol: str,
+        on_update: Callable[[pd.DataFrame], None],
+        *,
+        expiration: Optional[str] = None,
+        option_type: Optional[str] = None,
+        params: Optional[Dict[str, Any]] = None,
+        poll_interval: float = 5.0,
+        on_error: Optional[Callable[[Exception], None]] = None,
+    ) -> QuoteStreamHandle:
+        ...
+
+
+class MockDataProvider:
+    """In-memory provider that fabricates a realistic option chain."""
+
+    def __init__(self, seed: Optional[int] = None) -> None:
+        self._rng = np.random.default_rng(seed)
+
+    def get_spot(self, symbol: str) -> float:
+        base = 100 + (hash(symbol) % 50)
+        return float(base + self._rng.normal(0, 1.5))
+
+    def get_option_chain(
+        self,
+        symbol: str,
+        *,
+        expiration: Optional[str] = None,
+        option_type: Optional[str] = None,
+        params: Optional[Dict[str, Any]] = None,
+    ) -> pd.DataFrame:
+        params = params or {}
+        option_type = (option_type or "call").lower()
+        spot = params.get("spot") or self.get_spot(symbol)
+
+        strikes = params.get("strikes")
+        if not strikes:
+            strikes = np.linspace(spot * 0.8, spot * 1.2, num=11)
+
+        expiration = expiration or params.get("expiration") or "2024-12-20"
+        dte = params.get("dte", 30)
+        quote_time_ms = int(datetime.now(timezone.utc).timestamp() * 1000)
+
+        rows = []
+        for strike in strikes:
+            skew = 0.15 + 0.05 * (strike / spot - 1.0)
+            iv = abs(skew) + 0.18 + self._rng.normal(0, 0.01)
+            bid = max(0.05, max(spot - strike if option_type == "call" else strike - spot, 0.0))
+            noise = self._rng.normal(0, 0.1)
+            ask = max(bid + 0.05, bid + abs(noise))
+            mid = (bid + ask) / 2
+            last_trade = mid + self._rng.normal(0, 0.05)
+            contract_symbol = f"{symbol.upper()}{int(round(float(strike) * 100)):05d}{option_type[0].upper()}"
+            rows.append(
+                {
+                    "symbol": symbol.upper(),
+                    "contract_symbol": contract_symbol,
+                    "expiration": expiration,
+                    "dte": dte,
+                    "option_type": option_type,
+                    "strike": round(float(strike), 2),
+                    "bid": round(float(bid), 2),
+                    "ask": round(float(ask), 2),
+                    "mark": round(float(mid), 2),
+                    "trade_price": round(float(last_trade), 2),
+                    "last": round(float(last_trade), 2),
+                    "iv": round(float(iv), 4),
+                    "iv_percent": round(float(iv * 100.0), 2),
+                    "delta": round(float(self._rng.normal(0.45, 0.05)), 4),
+                    "gamma": round(float(self._rng.normal(0.01, 0.002)), 5),
+                    "theta": round(float(self._rng.normal(-0.03, 0.01)), 4),
+                    "vega": round(float(self._rng.normal(0.12, 0.02)), 4),
+                    "rho": round(float(self._rng.normal(0.05, 0.01)), 4),
+                    "volume": int(abs(self._rng.normal(250, 120))),
+                    "open_interest": int(abs(self._rng.normal(1200, 320))),
+                    "pl_open": round(float(self._rng.normal(0, 0.35)), 2),
+                    "pl_pct": round(float(self._rng.normal(0, 1.5)), 2),
+                    "underlying_price": round(float(spot), 2),
+                    "multiplier": 100,
+                    "quote_time": quote_time_ms,
+                }
+            )
+
+        df = pd.DataFrame(rows)
+        df = df.sort_values("strike").reset_index(drop=True)
+        df.attrs["underlying_price"] = float(spot)
+        return df
+
+    def stream_option_chain(
+        self,
+        symbol: str,
+        on_update: Callable[[pd.DataFrame], None],
+        *,
+        expiration: Optional[str] = None,
+        option_type: Optional[str] = None,
+        params: Optional[Dict[str, Any]] = None,
+        poll_interval: float = 5.0,
+        on_error: Optional[Callable[[Exception], None]] = None,
+    ) -> QuoteStreamHandle:
+        def fetch() -> pd.DataFrame:
+            return self.get_option_chain(
+                symbol,
+                expiration=expiration,
+                option_type=option_type,
+                params=params,
+            )
+
+        handle = QuoteStreamHandle(fetch, on_update, on_error, poll_interval)
+        handle.start()
+        return handle
+
+
+class SchwabClient(Protocol):
+    """Minimal protocol expected from a Schwab API client."""
+
+    def get_quote(self, symbol: str) -> Dict[str, Any]:
+        ...
+
+    def get_option_chain(self, symbol: str, **params: Any) -> Dict[str, Any]:
+        ...
+
+
+@dataclass
+class SchwabDataProvider:
+    """Adapter that converts Schwab API responses into simulator-friendly frames."""
+
+    client: SchwabClient
+
+    def get_spot(self, symbol: str) -> float:
+        quote = self.client.get_quote(symbol)
+        # Schwab market data responses may be nested under symbol keys or provide
+        # historical candles; probe a few known layouts before giving up.
+        candidates = []
+        if isinstance(quote, dict):
+            for key in (
+                "mark",
+                "markPrice",
+                "last",
+                "lastPrice",
+                "lastTrade",
+                "close",
+                "previousClose",
+                "regularMarketLastPrice",
+            ):
+                value = quote.get(key)
+                if value is not None:
+                    candidates.append(value)
+
+            if "quote" in quote and isinstance(quote["quote"], dict):
+                nested = quote["quote"]
+                for key in ("mark", "lastPrice", "close", "regularMarketLastPrice"):
+                    value = nested.get(key)
+                    if value is not None:
+                        candidates.append(value)
+
+            if "candles" in quote and quote["candles"]:
+                last_candle = quote["candles"][-1]
+                for key in ("close", "last", "lastPrice"):
+                    value = last_candle.get(key)
+                    if value is not None:
+                        candidates.append(value)
+
+        if candidates:
+            return float(candidates[0])
+
+        raise KeyError(f"Quote response missing price fields for {symbol}: {quote}")
+
+    def get_option_chain(
+        self,
+        symbol: str,
+        *,
+        expiration: Optional[str] = None,
+        option_type: Optional[str] = None,
+        params: Optional[Dict[str, Any]] = None,
+    ) -> pd.DataFrame:
+        params = params.copy() if params else {}
+        if expiration:
+            params.setdefault("expirationDate", expiration)
+        if option_type:
+            params.setdefault("contractType", option_type.upper())
+
+        raw = self.client.get_option_chain(symbol, **params)
+        return self._parse_option_chain(raw)
+
+    def stream_option_chain(
+        self,
+        symbol: str,
+        on_update: Callable[[pd.DataFrame], None],
+        *,
+        expiration: Optional[str] = None,
+        option_type: Optional[str] = None,
+        params: Optional[Dict[str, Any]] = None,
+        poll_interval: float = 5.0,
+        on_error: Optional[Callable[[Exception], None]] = None,
+    ) -> QuoteStreamHandle:
+        def fetch() -> pd.DataFrame:
+            return self.get_option_chain(
+                symbol,
+                expiration=expiration,
+                option_type=option_type,
+                params=params,
+            )
+
+        handle = QuoteStreamHandle(fetch, on_update, on_error, poll_interval)
+        handle.start()
+        return handle
+
+    @staticmethod
+    def _parse_option_chain(raw: Dict[str, Any]) -> pd.DataFrame:
+        """Flatten Schwab's nested option chain payload into a DataFrame."""
+
+        if not raw:
+            return pd.DataFrame(columns=[
+                "symbol",
+                "expiration",
+                "dte",
+                "option_type",
+                "strike",
+                "bid",
+                "ask",
+                "mark",
+                "last",
+                "iv",
+                "delta",
+                "gamma",
+                "theta",
+                "vega",
+                "rho",
+                "volume",
+                "open_interest",
+            ])
+
+        rows = []
+        underlying_symbol = (raw.get("symbol") or "").upper()
+        expirations = raw.get("callExpDateMap", {}) | raw.get("putExpDateMap", {})
+        for expiration, strikes in expirations.items():
+            # Schwab expiration keys look like "2024-12-20:30" (date:DTE)
+            exp_parts = expiration.split(":")
+            exp_date = exp_parts[0]
+            dte_hint = int(exp_parts[1]) if len(exp_parts) > 1 and exp_parts[1].isdigit() else None
+            for strike, contracts in strikes.items():
+                for contract in contracts:
+                    option_type = contract.get("putCall", "").lower()
+                    quote_time = contract.get("quoteTimeInLong") or contract.get("quoteTime")
+                    resolved_dte = contract.get("daysToExpiration") or dte_hint
+                    if resolved_dte in (None, ""):
+                        resolved_dte = _compute_dte(
+                            contract.get("expirationDate") or exp_date,
+                            quote_time,
+                        )
+
+                    mark = contract.get("markPrice", contract.get("mark"))
+                    if mark in (None, "") and contract.get("bidPrice") is not None and contract.get("askPrice") is not None:
+                        mark = (contract["bidPrice"] + contract["askPrice"]) / 2
+
+                    trade_price = contract.get("lastPrice", contract.get("last"))
+                    if trade_price in (None, ""):
+                        trade_price = contract.get("closePrice")
+
+                    raw_iv = contract.get("volatility")
+                    iv_decimal = None
+                    iv_percent = None
+                    if raw_iv not in (None, ""):
+                        iv_percent = float(raw_iv)
+                        iv_decimal = iv_percent / 100.0
+                    elif contract.get("iv") not in (None, ""):
+                        iv_decimal = float(contract.get("iv"))
+                        iv_percent = iv_decimal * 100.0
+
+                    rows.append(
+                        {
+                    "symbol": (underlying_symbol or (raw.get("underlying", {}) or {}).get("symbol", "")).upper(),
+                            "contract_symbol": contract.get("symbol"),
+                            "expiration": exp_date,
+                            "dte": resolved_dte,
+                            "option_type": option_type,
+                            "strike": float(contract.get("strikePrice", strike)),
+                            "bid": contract.get("bidPrice", contract.get("bid", 0.0)),
+                            "ask": contract.get("askPrice", contract.get("ask", 0.0)),
+                            "mark": mark,
+                            "trade_price": trade_price,
+                            "last": trade_price,
+                            "iv": iv_decimal,
+                            "iv_percent": iv_percent,
+                            "delta": contract.get("delta", 0.0),
+                            "gamma": contract.get("gamma", 0.0),
+                            "theta": contract.get("theta", 0.0),
+                            "vega": contract.get("vega", 0.0),
+                            "rho": contract.get("rho", 0.0),
+                            "volume": contract.get("totalVolume", 0),
+                            "open_interest": contract.get("openInterest", 0),
+                            "multiplier": contract.get("multiplier", raw.get("multiplier", 100)),
+                            "underlying_price": raw.get("underlyingPrice")
+                            or contract.get("underlyingPrice")
+                            or (raw.get("underlying", {}) or {}).get("mark"),
+                            "quote_time": quote_time,
+                            "pl_open": contract.get("netChange"),
+                            "pl_pct": contract.get("markPercentChange")
+                            or contract.get("percentChange"),
+                        }
+                    )
+
+        df = pd.DataFrame(rows)
+        if "underlyingPrice" in raw:
+            df.attrs["underlying_price"] = raw.get("underlyingPrice")
+        elif "underlying" in raw and isinstance(raw["underlying"], dict):
+            underlying_mark = raw["underlying"].get("mark") or raw["underlying"].get("last")
+            if underlying_mark is not None:
+                df.attrs["underlying_price"] = underlying_mark
+        return df
+
+
+def create_data_provider(
+    config: DataProviderConfig,
+    *,
+    schwab_client: Optional[SchwabClient] = None,
+) -> MarketDataProvider:
+    backend = config.backend.lower()
+    if backend == "mock":
+        seed = None
+        if config.params:
+            seed = config.params.get("seed")
+        return MockDataProvider(seed=seed)
+    if backend == "schwab":
+        if schwab_client is None:
+            if config.schwab is None:
+                raise ValueError(
+                    "Schwab configuration required when backend='schwab' and no client provided"
+                )
+            try:
+                from .schwab import SchwabRESTClient
+            except ImportError as exc:  # pragma: no cover - optional dependency guard
+                raise ImportError(
+                    "Schwab backend requires the optional 'requests' and 'cryptography' packages"
+                ) from exc
+
+            schwab_client = SchwabRESTClient(config.schwab)
+        return SchwabDataProvider(client=schwab_client)
+
+    raise ValueError(f"Unknown data provider backend: {config.backend}")
+

--- a/gld_mc/pricing.py
+++ b/gld_mc/pricing.py
@@ -28,3 +28,22 @@ def black_scholes_call(S, K, T, r, sigma):
     # intrinsic if effectively expired
     price = np.where(T <= tiny, np.maximum(S - K, 0.0), price)
     return price
+
+
+def black_scholes_put(S, K, T, r, sigma):
+    """Vectorized Black–Scholes put price."""
+    S = np.asarray(S, dtype=float)
+    T = np.asarray(T, dtype=float)
+
+    tiny = 1e-12
+    T_safe = np.maximum(T, tiny)
+
+    d1 = (np.log(S / K) + (r + 0.5 * sigma * sigma) * T_safe) / (sigma * np.sqrt(T_safe))
+    d2 = d1 - sigma * np.sqrt(T_safe)
+
+    Nd1 = norm_cdf(-d1)
+    Nd2 = norm_cdf(-d2)
+
+    price = (K * np.exp(-r * T_safe) * Nd2) - (S * Nd1)
+    price = np.where(T <= tiny, np.maximum(K - S, 0.0), price)
+    return price

--- a/gld_mc/schwab.py
+++ b/gld_mc/schwab.py
@@ -1,0 +1,338 @@
+"""Schwab API client utilities with encrypted token storage."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import os
+import time
+from collections import deque
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Optional
+from urllib.parse import urlencode
+
+import requests
+from requests import Response, Session
+
+from .config import SchwabAPIConfig
+
+try:  # pragma: no cover - optional dependency resolved at runtime
+    from cryptography.fernet import Fernet
+except ImportError as exc:  # pragma: no cover - bubble up a helpful error later
+    raise ImportError(
+        "The 'cryptography' package is required for Schwab token encryption"
+    ) from exc
+
+
+@dataclass
+class TokenBundle:
+    """OAuth tokens cached locally."""
+
+    access_token: str
+    refresh_token: str
+    expires_at: float
+
+    @classmethod
+    def from_response(cls, payload: Dict[str, Any]) -> "TokenBundle":
+        access = payload.get("access_token") or payload.get("accessToken")
+        refresh = payload.get("refresh_token") or payload.get("refreshToken")
+        expires_in = payload.get("expires_in") or payload.get("expiresIn") or 0
+
+        if not access or not refresh:
+            raise ValueError("Token response missing access or refresh token")
+
+        expires_at = time.time() + float(expires_in)
+        return cls(access_token=access, refresh_token=refresh, expires_at=expires_at)
+
+    def is_expired(self, skew_seconds: float = 30.0) -> bool:
+        return time.time() >= (self.expires_at - skew_seconds)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "access_token": self.access_token,
+            "refresh_token": self.refresh_token,
+            "expires_at": self.expires_at,
+        }
+
+
+class EncryptedTokenStore:
+    """Persist Schwab OAuth tokens encrypted on disk."""
+
+    def __init__(self, path: Path, passphrase: str) -> None:
+        if not passphrase:
+            raise ValueError("Passphrase required to initialize encrypted token store")
+        key = base64.urlsafe_b64encode(hashlib.sha256(passphrase.encode("utf-8")).digest())
+        self._fernet = Fernet(key)
+        self._path = path
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+
+    def load(self) -> Optional[TokenBundle]:
+        if not self._path.exists():
+            return None
+        data = self._path.read_bytes()
+        try:
+            decrypted = self._fernet.decrypt(data)
+        except Exception as exc:  # noqa: BLE001
+            raise ValueError("Failed to decrypt Schwab token cache") from exc
+        payload = json.loads(decrypted.decode("utf-8"))
+        return TokenBundle(
+            access_token=payload["access_token"],
+            refresh_token=payload["refresh_token"],
+            expires_at=float(payload["expires_at"]),
+        )
+
+    def save(self, bundle: TokenBundle) -> None:
+        serialized = json.dumps(bundle.to_dict()).encode("utf-8")
+        encrypted = self._fernet.encrypt(serialized)
+        self._path.write_bytes(encrypted)
+
+    def clear(self) -> None:
+        if self._path.exists():
+            self._path.unlink()
+
+
+class SchwabAuthManager:
+    """Handle OAuth flows and automatic refresh for Schwab APIs."""
+
+    authorize_endpoint = "https://api.schwabapi.com/v1/oauth/authorize"
+    token_endpoint = "https://api.schwabapi.com/v1/oauth/token"
+
+    def __init__(
+        self,
+        config: SchwabAPIConfig,
+        *,
+        session: Optional[Session] = None,
+    ) -> None:
+        self._config = config
+        self._session = session or requests.Session()
+
+        oauth_cfg = config.oauth
+        passphrase = os.getenv(oauth_cfg.encryption_passphrase_env, "")
+        if not passphrase:
+            raise RuntimeError(
+                f"Environment variable {oauth_cfg.encryption_passphrase_env} must be set"
+            )
+
+        self._store = EncryptedTokenStore(Path(oauth_cfg.token_cache).expanduser(), passphrase)
+        self._tokens: Optional[TokenBundle] = None
+
+    @property
+    def client_id(self) -> str:
+        oauth_cfg = self._config.oauth
+        if not oauth_cfg.client_id:
+            raise RuntimeError("Schwab client ID not configured")
+        return oauth_cfg.client_id
+
+    @property
+    def client_secret(self) -> str:
+        oauth_cfg = self._config.oauth
+        if not oauth_cfg.client_secret:
+            raise RuntimeError("Schwab client secret not configured")
+        return oauth_cfg.client_secret
+
+    @property
+    def redirect_uri(self) -> str:
+        oauth_cfg = self._config.oauth
+        if not oauth_cfg.redirect_uri:
+            raise RuntimeError("Schwab redirect URI not configured")
+        return oauth_cfg.redirect_uri
+
+    @property
+    def scopes(self) -> str:
+        return " ".join(self._config.oauth.scopes)
+
+    def authorization_url(self, state: Optional[str] = None) -> str:
+        params = {
+            "response_type": "code",
+            "client_id": self.client_id,
+            "redirect_uri": self.redirect_uri,
+            "scope": self.scopes,
+        }
+        if state:
+            params["state"] = state
+        return f"{self.authorize_endpoint}?{urlencode(params)}"
+
+    def exchange_authorization_code(self, code: str) -> TokenBundle:
+        payload = self._token_request(
+            {
+                "grant_type": "authorization_code",
+                "code": code,
+                "redirect_uri": self.redirect_uri,
+            }
+        )
+        bundle = TokenBundle.from_response(payload)
+        self._store.save(bundle)
+        self._tokens = bundle
+        return bundle
+
+    def refresh_access_token(self) -> TokenBundle:
+        bundle = self._tokens or self._store.load()
+        if not bundle:
+            raise RuntimeError(
+                "No Schwab refresh token available. Run the authorization code flow first."
+            )
+        payload = self._token_request(
+            {
+                "grant_type": "refresh_token",
+                "refresh_token": bundle.refresh_token,
+            }
+        )
+        # Schwab issues a new refresh token with each refresh. Persist it.
+        new_bundle = TokenBundle.from_response(payload)
+        self._store.save(new_bundle)
+        self._tokens = new_bundle
+        return new_bundle
+
+    def get_access_token(self) -> str:
+        bundle = self._tokens or self._store.load()
+        if not bundle:
+            raise RuntimeError(
+                "Schwab tokens not cached. Complete the initial OAuth handshake first."
+            )
+        if bundle.is_expired():
+            bundle = self.refresh_access_token()
+        else:
+            self._tokens = bundle
+        return bundle.access_token
+
+    def _token_request(self, data: Dict[str, Any]) -> Dict[str, Any]:
+        headers = {"Content-Type": "application/x-www-form-urlencoded"}
+        auth = (self.client_id, self.client_secret)
+        response = self._session.post(self.token_endpoint, data=data, headers=headers, auth=auth)
+        self._raise_for_status(response)
+        return response.json()
+
+    @staticmethod
+    def _raise_for_status(response: Response) -> None:
+        try:
+            response.raise_for_status()
+        except requests.HTTPError as exc:  # pragma: no cover - network errors
+            raise RuntimeError(
+                f"Schwab OAuth request failed ({response.status_code}): {response.text}"
+            ) from exc
+
+
+class RateLimiter:
+    """Token bucket limiting requests per minute."""
+
+    def __init__(self, max_per_minute: int) -> None:
+        self._max = max(0, max_per_minute)
+        self._events: deque[float] = deque()
+
+    def throttle(self) -> None:
+        if self._max <= 0:
+            return
+        now = time.time()
+        window_start = now - 60.0
+        while self._events and self._events[0] < window_start:
+            self._events.popleft()
+        if len(self._events) >= self._max:
+            sleep_for = 60.0 - (now - self._events[0])
+            if sleep_for > 0:
+                time.sleep(sleep_for)
+            return self.throttle()
+        self._events.append(time.time())
+
+
+class SchwabRESTClient:
+    """Concrete SchwabClient implementation backed by REST endpoints."""
+
+    def __init__(
+        self,
+        config: SchwabAPIConfig,
+        *,
+        session: Optional[Session] = None,
+        auth_manager: Optional[SchwabAuthManager] = None,
+    ) -> None:
+        self._config = config
+        self._session = session or requests.Session()
+        self._auth = auth_manager or SchwabAuthManager(config, session=self._session)
+        self._limiter = RateLimiter(config.rate_limit.max_requests_per_minute)
+
+    # --- SchwabClient protocol methods -------------------------------------------------
+    def get_quote(self, symbol: str) -> Dict[str, Any]:
+        url = f"{self._config.market_data_base}/{symbol}/quotes"
+        response = self._api_request("GET", url)
+        if isinstance(response, dict) and "quotes" in response:
+            # API may wrap quotes in {"quotes": {"AAPL": {...}}}
+            quotes = response["quotes"]
+            if isinstance(quotes, dict) and symbol.upper() in quotes:
+                return quotes[symbol.upper()]
+            return quotes
+        return response
+
+    def get_option_chain(self, symbol: str, **params: Any) -> Dict[str, Any]:
+        url = f"{self._config.market_data_base}/chains"
+        query = {"symbol": symbol, **params}
+        return self._api_request("GET", url, params=query)
+
+    # --- Helpers ----------------------------------------------------------------------
+    def _api_request(
+        self,
+        method: str,
+        url: str,
+        *,
+        params: Optional[Dict[str, Any]] = None,
+        data: Optional[Dict[str, Any]] = None,
+        retry: bool = True,
+    ) -> Dict[str, Any]:
+        self._limiter.throttle()
+        token = self._auth.get_access_token()
+        headers = {
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/json",
+        }
+        response = self._session.request(
+            method,
+            url,
+            params=params,
+            data=data,
+            headers=headers,
+            timeout=30,
+        )
+
+        if response.status_code == 401 and retry:
+            # Token likely expired but not marked yet. Refresh and retry once.
+            self._auth.refresh_access_token()
+            return self._api_request(
+                method,
+                url,
+                params=params,
+                data=data,
+                retry=False,
+            )
+
+        try:
+            response.raise_for_status()
+        except requests.HTTPError as exc:  # pragma: no cover - network errors
+            raise RuntimeError(
+                f"Schwab API request failed ({response.status_code}): {response.text}"
+            ) from exc
+
+        if response.headers.get("Content-Type", "").startswith("application/json"):
+            return response.json()
+        raise RuntimeError("Unexpected Schwab API response type; expected JSON")
+
+
+def main() -> None:  # pragma: no cover - convenience helper
+    """Interactive helper to complete the OAuth code exchange."""
+
+    from .config import SchwabAPIConfig
+
+    config = SchwabAPIConfig()
+    manager = SchwabAuthManager(config)
+    print("Schwab OAuth authorization")
+    print("===========================")
+    print("1. Visit the following URL in your browser and complete the login flow:")
+    print(manager.authorization_url())
+    print("2. After consenting, copy the 'code' query parameter from the redirect URL and paste it below.")
+    code = input("Authorization code: ").strip()
+    bundle = manager.exchange_authorization_code(code)
+    print("Tokens stored. Access token expires at:", time.ctime(bundle.expires_at))
+
+
+if __name__ == "__main__":  # pragma: no cover - manual usage
+    main()
+

--- a/gld_mc/sim.py
+++ b/gld_mc/sim.py
@@ -2,16 +2,26 @@ from __future__ import annotations
 import math
 import numpy as np
 import pandas as pd
-from dataclasses import asdict
 
 from .config import SimConfig
-from .pricing import black_scholes_call
+from .pricing import black_scholes_call, black_scholes_put
 
 def simulate(cfg: SimConfig):
     """
-    Run a single Monte-Carlo simulation for a long call with target/stop rules.
+    Run a single Monte-Carlo simulation for a long call or put with target/stop rules.
     Returns: (summary_df, details_df)
     """
+    option_type = cfg.option_type.lower()
+    if option_type not in {"call", "put"}:
+        raise NotImplementedError(f"option_type='{cfg.option_type}' is not yet supported")
+
+    if option_type == "call":
+        price_fn = black_scholes_call
+        intrinsic_fn = lambda spot: max(spot - cfg.strike, 0.0)
+    else:
+        price_fn = black_scholes_put
+        intrinsic_fn = lambda spot: max(cfg.strike - spot, 0.0)
+
     rng = np.random.default_rng(cfg.seed)
 
     trading_days = max(int(round(cfg.dte_calendar * (cfg.annual_trading_days / 365.0))), 1)
@@ -36,7 +46,7 @@ def simulate(cfg: SimConfig):
     exit_price  = np.zeros(cfg.num_trials, dtype=float)
     exit_reason = np.array(["hold"] * cfg.num_trials, dtype=object)
 
-    entry_cash = cfg.entry_price * 100.0 + cfg.commission_per_side
+    entry_cash = cfg.entry_price * cfg.contract_multiplier + cfg.commission_per_side
 
     for i in range(cfg.num_trials):
         sigma = sigmas[i]
@@ -48,8 +58,8 @@ def simulate(cfg: SimConfig):
             S = S * math.exp((mu - 0.5 * sigma * sigma) * dt + sigma * math.sqrt(dt) * z)
 
             T_rem = Ts[t]
-            C = black_scholes_call(S, cfg.strike, T_rem, cfg.risk_free_rate, sigma)
-            exit_cash = C * 100.0 - cfg.commission_per_side
+            option_price = price_fn(S, cfg.strike, T_rem, cfg.risk_free_rate, sigma)
+            exit_cash = option_price * cfg.contract_multiplier - cfg.commission_per_side
             pnl = exit_cash - entry_cash
 
             days_left = trading_days - (t + 1)
@@ -59,40 +69,46 @@ def simulate(cfg: SimConfig):
                 hit_target[i]  = True
                 hit_day[i]     = t + 1
                 final_pl[i]    = pnl
-                exit_price[i]  = C
+                exit_price[i]  = option_price
                 exit_reason[i] = "target"
                 exited = True
                 break
 
-            if can_exit and C <= cfg.stop_option_price:
+            if can_exit and option_price <= cfg.stop_option_price:
                 hit_target[i]  = False
                 hit_day[i]     = t + 1
                 final_pl[i]    = pnl
-                exit_price[i]  = C
+                exit_price[i]  = option_price
                 exit_reason[i] = "stop"
                 exited = True
                 break
 
         if not exited:
-            C_exp = max(S - cfg.strike, 0.0)
-            exit_cash = C_exp * 100.0 - cfg.commission_per_side
+            intrinsic = intrinsic_fn(S)
+            exit_cash = intrinsic * cfg.contract_multiplier - cfg.commission_per_side
             final_pl[i]    = exit_cash - entry_cash
-            exit_price[i]  = C_exp
-            exit_reason[i] = "expiry_ITM" if C_exp > 0 else "expiry_OTM"
+            exit_price[i]  = intrinsic
+            exit_reason[i] = "expiry_ITM" if intrinsic > 0 else "expiry_OTM"
 
     # Summary stats
     prob_hit = hit_target.mean()
     med_day  = float(np.median(hit_day[hit_day > 0])) if np.any(hit_day > 0) else float("nan")
     p5, p25, p50, p75, p95 = np.percentile(final_pl, [5, 25, 50, 75, 95])
 
+    option_label = cfg.option_type.lower()
+    option_display = {"call": "Call", "put": "Put"}.get(option_label, cfg.option_type)
+    expiration_display = cfg.expiration or "n/a"
+
     summary = pd.DataFrame({
         "Metric": [
-            "Trials", "Trading Days", "IV Mode", "IV Fixed", "IV Range",
-            "Drift Mode", "Drift (annual)", "Entry Price", "Strike", "Target Profit",
+            "Symbol", "Option Type", "Expiration", "Contract Multiplier", "Trials",
+            "Trading Days", "IV Mode", "IV Fixed", "IV Range", "Drift Mode",
+            "Drift (annual)", "Entry Price", "Strike", "Target Profit",
             "Stop (option price)", "P(hit target before expiry)", "Median day to hit target",
             "Mean Final P&L", "P&L p5", "P&L p25", "P&L p50", "P&L p75", "P&L p95"
         ],
         "Value": [
+            cfg.symbol, option_display, expiration_display, cfg.contract_multiplier,
             f"{cfg.num_trials:,}", trading_days, cfg.iv_mode, cfg.iv_fixed,
             f"{cfg.iv_min}–{cfg.iv_max}", cfg.mu_mode, cfg.mu_custom,
             f"${cfg.entry_price:.2f}", cfg.strike, f"${cfg.target_profit:.0f}",

--- a/gld_mc/ui.py
+++ b/gld_mc/ui.py
@@ -1,26 +1,325 @@
 #!/usr/bin/env python3
 # Simple Tkinter UI for GLD Long Call Monte Carlo (Single + Batch tabs)
 from __future__ import annotations
+
 import os
 import time
 import tkinter as tk
-from tkinter import ttk, messagebox
+from datetime import datetime, timezone
+from tkinter import messagebox, ttk
+from typing import Any, Callable, Dict, Optional
 
-import numpy as np
-import pandas as pd
 import matplotlib.pyplot as plt
+import pandas as pd
 from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg
 
-from .config import SimConfig
+from .config import DataProviderConfig, SimConfig
+from .data_provider import QuoteStreamHandle, create_data_provider
 from .sim import simulate
 
 PAD = 10
 
+
+def contract_key(row: pd.Series | None) -> Optional[tuple[Any, ...]]:
+    if row is None:
+        return None
+    return (
+        (row.get("symbol") or "").upper(),
+        row.get("expiration"),
+        (row.get("option_type") or "").lower(),
+        round(float(row.get("strike", 0.0)), 4),
+    )
+
+
+class ContractCell(tk.Frame):
+    """Visual representation of a single call or put contract."""
+
+    DEFAULT_BG = "white"
+    SELECT_BG = "#fffbe6"
+    SELECT_BORDER = "#8cb6ff"
+
+    def __init__(
+        self,
+        viewer: "OptionsChainViewer",
+        parent,
+        contract: pd.Series | None,
+        *,
+        side: str,
+    ) -> None:
+        super().__init__(parent, bd=1, relief="solid", background=self.DEFAULT_BG, highlightthickness=0)
+        self.viewer = viewer
+        if contract is not None and not isinstance(contract, pd.Series):
+            contract = pd.Series(contract)
+        self.contract: pd.Series | None = contract.copy() if isinstance(contract, pd.Series) else None
+        self.side = side
+        self.key = contract_key(self.contract) if self.contract is not None else None
+
+        text = self._build_text()
+        self.label = tk.Label(
+            self,
+            text=text,
+            justify="left",
+            anchor="nw",
+            bg=self.DEFAULT_BG,
+            font=("TkDefaultFont", 9),
+        )
+        self.label.pack(fill="both", expand=True, padx=6, pady=4)
+
+        if self.contract is not None:
+            for widget in (self, self.label):
+                widget.bind("<Button-1>", self._on_click)
+                widget.bind("<Double-Button-1>", self._on_double_click)
+
+    def _build_text(self) -> str:
+        metrics = self.viewer.metrics
+        header = (self.contract.get("option_type") if self.contract is not None else self.side).upper()
+        lines = [header]
+        for label, column in metrics:
+            value = self.contract.get(column) if self.contract is not None else None
+            lines.append(f"{label}: {self.viewer.format_metric(column, value)}")
+        return "\n".join(lines)
+
+    def set_selected(self, selected: bool) -> None:
+        if selected:
+            self.configure(
+                highlightthickness=2,
+                highlightbackground=self.SELECT_BORDER,
+                highlightcolor=self.SELECT_BORDER,
+                background=self.SELECT_BG,
+            )
+            self.label.configure(bg=self.SELECT_BG)
+        else:
+            self.configure(highlightthickness=0, background=self.DEFAULT_BG)
+            self.label.configure(bg=self.DEFAULT_BG)
+
+    def _on_click(self, _event) -> None:
+        self.viewer._handle_cell_click(self, double=False)
+
+    def _on_double_click(self, _event) -> None:
+        self.viewer._handle_cell_click(self, double=True)
+
+
+class OptionsChainViewer(ttk.Frame):
+    """Scrollable matrix of call/put contracts grouped by strike."""
+
+    metrics = [
+        ("DTE", "dte"),
+        ("Mark", "mark"),
+        ("Trade Price", "trade_price"),
+        ("P/L Open", "pl_open"),
+        ("P/L %", "pl_pct"),
+        ("Delta", "delta"),
+        ("Theta", "theta"),
+        ("Vega", "vega"),
+        ("IV%", "iv_percent"),
+        ("Volume", "volume"),
+        ("Open Interest", "open_interest"),
+    ]
+
+    def __init__(
+        self,
+        parent,
+        on_select: Callable[[pd.Series], None] | None = None,
+        *,
+        on_activate: Callable[[pd.Series], None] | None = None,
+    ) -> None:
+        super().__init__(parent, padding=PAD)
+
+        self._on_select = on_select
+        self._on_activate = on_activate
+        self._data = pd.DataFrame()
+        self._cells_by_key: dict[tuple[Any, ...], ContractCell] = {}
+        self._selected_cell: ContractCell | None = None
+        self._selected_key: tuple[Any, ...] | None = None
+
+        self._last_update = tk.StringVar(value="")
+        self._underlying_var = tk.StringVar(value="")
+
+        header = ttk.Frame(self)
+        header.pack(fill="x", pady=(0, PAD))
+        ttk.Label(header, text="Live Option Chain", font=("TkDefaultFont", 11, "bold")).pack(side="left")
+        ttk.Label(header, textvariable=self._underlying_var).pack(side="right")
+        ttk.Label(header, textvariable=self._last_update).pack(side="right", padx=(0, PAD))
+
+        self.canvas = tk.Canvas(self, borderwidth=0, highlightthickness=0)
+        self.canvas.pack(side="left", fill="both", expand=True)
+        vsb = ttk.Scrollbar(self, orient="vertical", command=self.canvas.yview)
+        vsb.pack(side="right", fill="y")
+        self.canvas.configure(yscrollcommand=vsb.set)
+
+        self._table = ttk.Frame(self.canvas)
+        self._window = self.canvas.create_window((0, 0), window=self._table, anchor="nw")
+        self._table.bind("<Configure>", self._on_table_configure)
+        self.canvas.bind("<Configure>", self._on_canvas_resize)
+
+    def _on_table_configure(self, _event) -> None:
+        self.canvas.configure(scrollregion=self.canvas.bbox("all"))
+
+    def _on_canvas_resize(self, event) -> None:
+        self.canvas.itemconfigure(self._window, width=event.width)
+
+    def clear(self) -> None:
+        for child in self._table.winfo_children():
+            child.destroy()
+        self._cells_by_key.clear()
+        if self._selected_cell is not None:
+            self._selected_cell.set_selected(False)
+        self._selected_cell = None
+        self._selected_key = None
+
+    def update_underlying(self, price: float | None) -> None:
+        if price is None:
+            self._underlying_var.set("")
+        else:
+            self._underlying_var.set(f"Spot: {price:.2f}")
+
+    def update_from_dataframe(self, df: pd.DataFrame, timestamp: str | None = None) -> None:
+        current_key = self._selected_key
+        self._data = df.reset_index(drop=True)
+        self.clear()
+
+        if df.empty:
+            self._last_update.set("No data")
+        else:
+            grouped: dict[tuple[Any, float], dict[str, pd.Series]] = {}
+            for _, row in self._data.iterrows():
+                strike = float(row.get("strike", 0.0))
+                expiration = row.get("expiration")
+                option_type = (row.get("option_type") or "").lower()
+                key = (expiration, strike)
+                grouped.setdefault(key, {})[option_type] = row
+
+            self._build_header_row()
+
+            for idx, ((expiration, strike), legs) in enumerate(
+                sorted(grouped.items(), key=lambda item: (item[0][0] or "", item[0][1]))
+            , start=1):
+                call_row = legs.get("call")
+                put_row = legs.get("put")
+                call_cell = self._create_cell(call_row, side="call")
+                call_cell.grid(row=idx, column=0, sticky="nsew", padx=(0, PAD // 2), pady=4)
+
+                strike_text = f"{strike:.2f}\n{expiration or ''}"
+                ttk.Label(
+                    self._table,
+                    text=strike_text,
+                    anchor="center",
+                    font=("TkDefaultFont", 10, "bold"),
+                ).grid(row=idx, column=1, sticky="nsew", padx=4, pady=4)
+
+                put_cell = self._create_cell(put_row, side="put")
+                put_cell.grid(row=idx, column=2, sticky="nsew", padx=(PAD // 2, 0), pady=4)
+
+                self._table.rowconfigure(idx, weight=1)
+
+            self._table.columnconfigure(0, weight=1)
+            self._table.columnconfigure(1, weight=0)
+            self._table.columnconfigure(2, weight=1)
+
+            if timestamp:
+                self._last_update.set(f"Updated {timestamp}")
+            else:
+                self._last_update.set("Updated")
+
+            if current_key is not None:
+                self.select_by_key(current_key)
+
+    def _build_header_row(self) -> None:
+        ttk.Label(
+            self._table,
+            text="CALLS",
+            font=("TkDefaultFont", 10, "bold"),
+            anchor="center",
+        ).grid(row=0, column=0, sticky="ew", pady=(0, 4))
+        ttk.Label(
+            self._table,
+            text="STRIKE",
+            font=("TkDefaultFont", 10, "bold"),
+            anchor="center",
+        ).grid(row=0, column=1, sticky="ew", pady=(0, 4))
+        ttk.Label(
+            self._table,
+            text="PUTS",
+            font=("TkDefaultFont", 10, "bold"),
+            anchor="center",
+        ).grid(row=0, column=2, sticky="ew", pady=(0, 4))
+
+    def _create_cell(self, row: pd.Series | None, *, side: str) -> ContractCell:
+        cell = ContractCell(self, self._table, row, side=side)
+        if cell.contract is not None and cell.key is not None:
+            self._cells_by_key[cell.key] = cell
+        return cell
+
+    def _handle_cell_click(self, cell: ContractCell, *, double: bool) -> None:
+        if cell.contract is None:
+            return
+        self._set_selection(cell, notify=not double)
+        if double and self._on_activate is not None:
+            self._on_activate(cell.contract)
+        elif not double and self._on_select is not None:
+            self._on_select(cell.contract)
+
+    def _set_selection(self, cell: ContractCell, *, notify: bool = True) -> None:
+        if self._selected_cell is cell:
+            return
+        if self._selected_cell is not None:
+            self._selected_cell.set_selected(False)
+        self._selected_cell = cell
+        self._selected_key = cell.key
+        cell.set_selected(True)
+        if notify and self._on_select is not None and cell.contract is not None:
+            self._on_select(cell.contract)
+
+    def clear_selection(self) -> None:
+        if self._selected_cell is not None:
+            self._selected_cell.set_selected(False)
+        self._selected_cell = None
+        self._selected_key = None
+
+    def select_by_key(self, key: tuple[Any, ...]) -> None:
+        cell = self._cells_by_key.get(key)
+        if cell is not None:
+            self._set_selection(cell, notify=False)
+
+    def get_selected_row(self) -> pd.Series | None:
+        if self._selected_cell is not None:
+            return self._selected_cell.contract
+        return None
+
+    def format_metric(self, column: str, value: Any) -> str:
+        if value is None or (isinstance(value, str) and not value) or pd.isna(value):
+            return "-f"
+        try:
+            if column == "dte":
+                return f"{int(round(float(value)))}"
+            if column in {"mark", "trade_price", "pl_open"}:
+                return f"{float(value):.2f}"
+            if column in {"pl_pct", "iv_percent"}:
+                pct = float(value)
+                if column == "iv_percent" and abs(pct) < 1:
+                    pct *= 100.0
+                return f"{pct:.2f}%"
+            if column in {"delta", "theta", "vega"}:
+                return f"{float(value):.4f}"
+            if column in {"volume", "open_interest"}:
+                return f"{int(round(float(value)))}"
+        except Exception:  # noqa: BLE001
+            return str(value)
+        return str(value)
+
 class SimUI(tk.Tk):
     def __init__(self):
         super().__init__()
-        self.title("GLD Long Call Monte Carlo")
-        self.geometry("940x780")
+        self.title("Options Monte Carlo Simulator")
+        self.geometry("1050x820")
+        self.data_settings = DataProviderConfig()
+        self.data_provider = create_data_provider(self.data_settings)
+        self._chain_handle: QuoteStreamHandle | None = None
+        self._latest_chain: pd.DataFrame | None = None
+        self._latest_underlying_price: float | None = None
+        self._selected_contract: pd.Series | None = None
+        self._selected_contract_key: Optional[tuple[Any, ...]] = None
+        self._selection_status = tk.StringVar(value="No contract selected")
         self._build_notebook()
 
     def _build_notebook(self):
@@ -43,6 +342,24 @@ class SimUI(tk.Tk):
     def _build_single_tab(self, root):
         root = ttk.Frame(root, padding=PAD)
         root.pack(fill="both", expand=True)
+
+        default_symbol = self.data_settings.default_symbol or "GLD"
+
+        # --- Instrument ---
+        isec = ttk.LabelFrame(root, text="Instrument", padding=PAD)
+        isec.pack(fill="x", expand=False, pady=(0, PAD))
+
+        self.var_symbol = tk.StringVar(value=default_symbol)
+        self.var_option_type = tk.StringVar(value=self.data_settings.default_option_type)
+        self.var_expiration = tk.StringVar(value=self.data_settings.default_expiration or "")
+
+        self._add_labeled_entry(isec, "Symbol", self.var_symbol, 0, 0)
+        self._add_combo(isec, "Option type", self.var_option_type, ["call", "put"], 0, 1)
+        self._add_labeled_entry(isec, "Expiration (YYYY-MM-DD)", self.var_expiration, 1, 0)
+        mult_frame = ttk.Frame(isec)
+        mult_frame.grid(row=1, column=1, sticky="w", padx=(0, PAD), pady=5)
+        ttk.Label(mult_frame, text="Contract multiplier").pack(side="top", anchor="w")
+        ttk.Label(mult_frame, text="100 (fixed)").pack(side="top", anchor="w")
 
         # --- Market & Contract
         msec = ttk.LabelFrame(root, text="Market & Contract", padding=PAD)
@@ -110,15 +427,37 @@ class SimUI(tk.Tk):
         self._add_combo(dsec, "μ mode", self.var_mu_mode, ["risk_neutral", "custom"], 0, 0)
         self._add_labeled_entry(dsec, "μ custom (annual)", self.var_mu_custom, 0, 1)
 
+        # --- Live Market Data
+        mdat = ttk.LabelFrame(root, text="Live Market Data", padding=PAD)
+        mdat.pack(fill="both", expand=True, pady=(0, PAD))
+
+        controls = ttk.Frame(mdat)
+        controls.pack(fill="x", pady=(0, PAD))
+        ttk.Button(controls, text="Start Stream", command=self._start_chain_stream).pack(side="left")
+        ttk.Button(controls, text="Stop Stream", command=self._stop_chain_stream).pack(side="left", padx=(PAD, 0))
+        ttk.Button(controls, text="Simulate Trade", command=self._select_contract_for_simulation).pack(
+            side="left", padx=(PAD, 0)
+        )
+        ttk.Button(controls, text="Copy Last Chain", command=self._copy_chain_to_clipboard).pack(side="right")
+
+        self.chain_view = OptionsChainViewer(
+            mdat,
+            on_select=self._handle_chain_preview,
+            on_activate=self._on_contract_activate,
+        )
+        self.chain_view.pack(fill="both", expand=True)
+        ttk.Label(mdat, textvariable=self._selection_status).pack(anchor="w", pady=(PAD // 2, 0))
+
         # --- Buttons
         btn_row = ttk.Frame(root, padding=(0, PAD))
         btn_row.pack(fill="x", expand=False)
         ttk.Button(btn_row, text="Run Simulation", command=self._run_single).pack(side="left")
         ttk.Button(btn_row, text="Quit", command=self.destroy).pack(side="right")
 
-        ttk.Label(root, text="Charts appear in a separate Results window. CSVs saved to ./out/").pack(
-            side="bottom", anchor="w"
-        )
+        ttk.Label(root, text="Charts appear in a separate Results window. CSVs saved to ./out/").pack(side="bottom", anchor="w")
+
+        if self.data_settings.auto_start_stream:
+            self.after(200, self._start_chain_stream)
 
     # ======= BATCH TAB =======
     def _build_batch_tab(self, root):
@@ -126,6 +465,22 @@ class SimUI(tk.Tk):
         root.pack(fill="both", expand=True)
 
         # Reuse same-style blocks but with separate variables (so Single and Batch are independent)
+
+        # --- Instrument ---
+        b_inst = ttk.LabelFrame(root, text="Instrument", padding=PAD)
+        b_inst.pack(fill="x", expand=False, pady=(0, PAD))
+
+        self.b_symbol = tk.StringVar(value=self.data_settings.default_symbol or "GLD")
+        self.b_option_type = tk.StringVar(value=self.data_settings.default_option_type)
+        self.b_expiration = tk.StringVar(value=self.data_settings.default_expiration or "")
+
+        self._add_labeled_entry(b_inst, "Symbol", self.b_symbol, 0, 0)
+        self._add_combo(b_inst, "Option type", self.b_option_type, ["call", "put"], 0, 1)
+        self._add_labeled_entry(b_inst, "Expiration (YYYY-MM-DD)", self.b_expiration, 1, 0)
+        mult_frame = ttk.Frame(b_inst)
+        mult_frame.grid(row=1, column=1, sticky="w", padx=(0, PAD), pady=5)
+        ttk.Label(mult_frame, text="Contract multiplier").pack(side="top", anchor="w")
+        ttk.Label(mult_frame, text="100 (fixed)").pack(side="top", anchor="w")
 
         # --- Market & Contract
         msec = ttk.LabelFrame(root, text="Market & Contract (shared across strikes)", padding=PAD)
@@ -211,6 +566,358 @@ class SimUI(tk.Tk):
             side="bottom", anchor="w"
         )
 
+    # ======= Market data =======
+    def _start_chain_stream(self) -> None:
+        symbol = self.var_symbol.get().strip().upper() or (self.data_settings.default_symbol or "GLD")
+        expiration = self.var_expiration.get().strip() or None
+        option_filter = None
+
+        params = dict(self.data_settings.params) if self.data_settings.params else {}
+
+        self._stop_chain_stream()
+        self._selected_contract = None
+        self._selected_contract_key = None
+        self._selection_status.set("No contract selected")
+        self.chain_view.clear_selection()
+
+        try:
+            self._chain_handle = self.data_provider.stream_option_chain(
+                symbol=symbol,
+                expiration=expiration,
+                option_type=option_filter,
+                params=params,
+                poll_interval=self.data_settings.poll_interval,
+                on_update=self._handle_chain_update,
+                on_error=self._handle_chain_error,
+            )
+        except Exception as exc:  # noqa: BLE001 - present provider errors to the user
+            self._chain_handle = None
+            messagebox.showerror("Market data", f"Failed to start option chain stream:\n{exc}")
+
+    def _stop_chain_stream(self) -> None:
+        if self._chain_handle is not None:
+            self._chain_handle.stop()
+            self._chain_handle = None
+
+    def _handle_chain_update(self, df: pd.DataFrame) -> None:
+        timestamp = time.strftime("%H:%M:%S")
+        prepared = self._prepare_chain_dataframe(df)
+
+        underlying = None
+        if hasattr(df, "attrs"):
+            underlying = df.attrs.get("underlying_price")
+        if underlying is None and "underlying_price" in prepared.columns:
+            series = prepared["underlying_price"].dropna()
+            if not series.empty:
+                underlying = float(series.iloc[0])
+        if underlying is not None:
+            self._latest_underlying_price = float(underlying)
+
+        self._latest_chain = prepared
+
+        def _update() -> None:
+            self.chain_view.update_underlying(self._latest_underlying_price)
+            self.chain_view.update_from_dataframe(prepared, timestamp)
+            self._refresh_selected_contract()
+
+        self.after(0, _update)
+
+    def _handle_chain_error(self, exc: Exception) -> None:
+        def _show() -> None:
+            messagebox.showerror("Market data stream", str(exc))
+
+        self.after(0, _show)
+        self._stop_chain_stream()
+
+    def _copy_chain_to_clipboard(self) -> None:
+        if self._latest_chain is None or self._latest_chain.empty:
+            messagebox.showinfo("Copy option chain", "No option chain data available yet.")
+            return
+
+        try:
+            csv_text = self._latest_chain.to_csv(index=False)
+            self.clipboard_clear()
+            self.clipboard_append(csv_text)
+            messagebox.showinfo("Copy option chain", "Latest option chain copied to clipboard (CSV format).")
+        except Exception as exc:  # noqa: BLE001
+            messagebox.showerror("Copy option chain", f"Failed to copy option chain:\n{exc}")
+
+    def _handle_chain_preview(self, row: pd.Series) -> None:
+        self._selection_status.set(self._format_contract_caption(row, prefix="Preview"))
+
+    def _on_contract_activate(self, row: pd.Series) -> None:
+        self._select_contract_for_simulation(row)
+
+    def _select_contract_for_simulation(self, row: pd.Series | None = None) -> None:
+        if self._latest_chain is None or self._latest_chain.empty:
+            messagebox.showinfo("Simulate trade", "Stream an option chain before selecting a contract.")
+            return
+
+        if row is None:
+            row = self.chain_view.get_selected_row()
+            if row is None:
+                messagebox.showinfo("Simulate trade", "Single-click a contract, then press Simulate Trade.")
+                return
+
+        inputs = self._extract_contract_inputs(row)
+        if inputs["entry"] is None:
+            messagebox.showerror(
+                "Simulate trade",
+                "The selected contract is missing a mark or trade price. Wait for data or choose another strike.",
+            )
+            return
+        if inputs["spot"] is None:
+            messagebox.showerror(
+                "Simulate trade",
+                "Unable to determine the underlying spot price from the live chain.",
+            )
+            return
+        if inputs["dte"] is None:
+            messagebox.showerror(
+                "Simulate trade",
+                "Days to expiration are unavailable for the selected contract.",
+            )
+            return
+
+        self._apply_contract_to_forms(inputs)
+        self._selected_contract = row.copy()
+        self._selected_contract_key = contract_key(row)
+        if self._selected_contract_key is not None:
+            self.chain_view.select_by_key(self._selected_contract_key)
+        self._selection_status.set(self._format_contract_caption(row, prefix="Selected"))
+
+    def _format_contract_caption(self, row: pd.Series | None, *, prefix: str) -> str:
+        if row is None:
+            return "No contract selected"
+        symbol = (row.get("symbol") or "").upper()
+        option_type = (row.get("option_type") or "").upper()
+        strike = self._safe_float(row, "strike")
+        expiration = row.get("expiration") or ""
+        strike_text = f"{strike:.2f}" if strike is not None else "?"
+        exp_text = f" exp {expiration}" if expiration else ""
+        return f"{prefix}: {symbol} {option_type} {strike_text}{exp_text}"
+
+    def _safe_float(self, row: pd.Series, column: str) -> Optional[float]:
+        if column not in row:
+            return None
+        value = row.get(column)
+        if value is None or (isinstance(value, str) and not value):
+            return None
+        try:
+            if pd.isna(value):
+                return None
+        except Exception:  # noqa: BLE001
+            pass
+        try:
+            return float(value)
+        except Exception:  # noqa: BLE001
+            return None
+
+    def _resolve_dte(self, row: pd.Series) -> Optional[int]:
+        dte_value = row.get("dte")
+        if dte_value is not None:
+            try:
+                if not pd.isna(dte_value):
+                    return max(int(round(float(dte_value))), 0)
+            except Exception:  # noqa: BLE001
+                pass
+
+        expiration = row.get("expiration")
+        if not expiration or pd.isna(expiration):
+            return None
+
+        quote_time = self._safe_float(row, "quote_time")
+        if quote_time is not None:
+            base_dt = datetime.fromtimestamp(quote_time / 1000.0, tz=timezone.utc)
+        else:
+            base_dt = datetime.now(timezone.utc)
+
+        try:
+            exp_date = datetime.fromisoformat(str(expiration)[:10]).date()
+        except ValueError:
+            return None
+
+        return max((exp_date - base_dt.date()).days, 0)
+
+    def _resolve_spot(self, row: pd.Series) -> Optional[float]:
+        spot = self._safe_float(row, "underlying_price")
+        if spot is None and self._latest_underlying_price is not None:
+            spot = float(self._latest_underlying_price)
+        if spot is None:
+            spot = self._safe_float(row, "spot")
+        return spot
+
+    def _extract_contract_inputs(self, row: pd.Series) -> Dict[str, Any]:
+        strike = self._safe_float(row, "strike")
+        mark = self._safe_float(row, "mark")
+        trade_price = self._safe_float(row, "trade_price")
+        if trade_price is None:
+            trade_price = self._safe_float(row, "last")
+        entry = mark if mark is not None and mark > 0 else trade_price
+
+        iv = self._safe_float(row, "iv")
+        if iv is None or iv <= 0:
+            iv_percent = self._safe_float(row, "iv_percent")
+            if iv_percent is not None:
+                iv = iv_percent / 100.0 if abs(iv_percent) > 1 else iv_percent
+
+        dte = self._resolve_dte(row)
+        spot = self._resolve_spot(row)
+
+        expiration = row.get("expiration")
+        if isinstance(expiration, str):
+            expiration_value = expiration
+        else:
+            expiration_value = None
+
+        symbol = (row.get("symbol") or self.var_symbol.get() or "").upper()
+        option_type = (row.get("option_type") or self.var_option_type.get() or "call").lower()
+
+        return {
+            "symbol": symbol,
+            "option_type": option_type,
+            "expiration": expiration_value,
+            "strike": strike,
+            "mark": mark,
+            "trade_price": trade_price,
+            "entry": entry,
+            "iv": iv,
+            "dte": dte,
+            "spot": spot,
+        }
+
+    def _apply_contract_to_forms(self, inputs: Dict[str, Any]) -> None:
+        symbol = inputs["symbol"]
+        option_type = inputs["option_type"]
+        expiration = inputs.get("expiration")
+        strike = inputs.get("strike")
+        entry = inputs.get("entry")
+        dte = inputs.get("dte")
+        spot = inputs.get("spot")
+        iv = inputs.get("iv")
+
+        if symbol:
+            self.var_symbol.set(symbol)
+            self.b_symbol.set(symbol)
+        if option_type:
+            self.var_option_type.set(option_type)
+            self.b_option_type.set(option_type)
+        if expiration:
+            self.var_expiration.set(expiration)
+            self.b_expiration.set(expiration)
+        if strike is not None:
+            self.var_strike.set(float(strike))
+        if entry is not None:
+            self.var_entry.set(float(entry))
+            self.b_entry.set(float(entry))
+        if dte is not None:
+            self.var_dte.set(int(dte))
+            self.b_dte.set(int(dte))
+        if spot is not None:
+            self.var_spot.set(float(spot))
+            self.b_spot.set(float(spot))
+        if iv is not None and iv > 0:
+            self.var_iv_mode.set("fixed")
+            self.var_iv_fixed.set(float(iv))
+            self.b_iv_mode.set("fixed")
+            self.b_iv_fixed.set(float(iv))
+
+        if strike is not None:
+            strike_text = f"{float(strike):.2f}"
+            current = [s.strip() for s in self.b_strikes_text.get().split(",") if s.strip()]
+            if strike_text not in current:
+                current.append(strike_text)
+                self.b_strikes_text.set(", ".join(current))
+
+    def _prepare_chain_dataframe(self, df: pd.DataFrame) -> pd.DataFrame:
+        data = df.copy()
+        data.attrs = dict(getattr(df, "attrs", {}))
+        if data.empty:
+            return data
+
+        if "option_type" in data.columns:
+            data["option_type"] = data["option_type"].fillna("").astype(str).str.lower()
+        if "symbol" in data.columns:
+            data["symbol"] = data["symbol"].fillna("").astype(str).str.upper()
+        if "strike" in data.columns:
+            data["strike"] = pd.to_numeric(data["strike"], errors="coerce")
+        if "mark" in data.columns:
+            data["mark"] = pd.to_numeric(data["mark"], errors="coerce")
+
+        if "trade_price" not in data.columns:
+            data["trade_price"] = data.get("last", pd.NA)
+        if "pl_open" not in data.columns:
+            data["pl_open"] = pd.NA
+        if "pl_pct" not in data.columns:
+            data["pl_pct"] = pd.NA
+        if "iv_percent" not in data.columns:
+            if "iv" in data.columns:
+                data["iv_percent"] = data["iv"] * 100.0
+            else:
+                data["iv_percent"] = pd.NA
+        if "quote_time" not in data.columns:
+            data["quote_time"] = pd.NA
+        if "underlying_price" not in data.columns:
+            data["underlying_price"] = pd.NA
+
+        data["dte"] = data.apply(self._resolve_dte, axis=1)
+        return data
+
+    def _find_contract_by_key(
+        self,
+        key: tuple[Any, ...],
+        df: pd.DataFrame | None = None,
+    ) -> Optional[pd.Series]:
+        data = df if df is not None else self._latest_chain
+        if data is None or data.empty:
+            return None
+
+        symbol, expiration, option_type, strike = key
+        mask = data["symbol"].str.upper() == symbol
+        if expiration:
+            mask &= data["expiration"] == expiration
+        mask &= data["option_type"] == option_type
+        mask &= data["strike"].sub(strike).abs() < 1e-6
+        matches = data.loc[mask]
+        if matches.empty:
+            return None
+        return matches.iloc[0]
+
+    def _refresh_selected_contract(self) -> None:
+        if self._selected_contract_key is None:
+            return
+        match = self._find_contract_by_key(self._selected_contract_key)
+        if match is None:
+            self._selected_contract = None
+            self._selected_contract_key = None
+            self._selection_status.set("No contract selected")
+            self.chain_view.clear_selection()
+        else:
+            self._selected_contract = match.copy()
+            self.chain_view.select_by_key(self._selected_contract_key)
+            self._selection_status.set(self._format_contract_caption(match, prefix="Selected"))
+
+    def _find_contract(
+        self,
+        *,
+        symbol: str,
+        option_type: str,
+        strike: float,
+        expiration: Optional[str] = None,
+    ) -> Optional[pd.Series]:
+        if self._latest_chain is None or self._latest_chain.empty:
+            return None
+
+        df = self._latest_chain
+        mask = (df["symbol"] == symbol.upper()) & (df["option_type"] == option_type)
+        mask &= df["strike"].sub(strike).abs() < 1e-6
+        if expiration:
+            mask &= df["expiration"] == expiration
+        matches = df.loc[mask]
+        if matches.empty:
+            return None
+        return matches.iloc[0]
+
     # ======= Helpers =======
     def _add_labeled_entry(self, parent, text, var, row, col):
         frm = ttk.Frame(parent)
@@ -224,62 +931,125 @@ class SimUI(tk.Tk):
         ttk.Label(frm, text=label).pack(side="top", anchor="w")
         ttk.Combobox(frm, textvariable=var, values=values, width=18, state="readonly").pack(side="top", anchor="w")
 
-    def _collect_config_single(self) -> SimConfig:
-        return SimConfig(
-            spot=self.var_spot.get(),
-            strike=self.var_strike.get(),
-            dte_calendar=self.var_dte.get(),
-            annual_trading_days=self.var_annual.get(),
-            risk_free_rate=self.var_rfr.get(),
-            iv_mode=self.var_iv_mode.get(),
-            iv_fixed=self.var_iv_fixed.get(),
-            iv_min=self.var_iv_min.get(),
-            iv_max=self.var_iv_max.get(),
-            num_trials=self.var_trials.get(),
-            seed=self.var_seed.get(),
-            entry_price=self.var_entry.get(),
-            commission_per_side=self.var_comm.get(),
-            target_profit=self.var_target.get(),
-            stop_option_price=self.var_stop.get(),
-            avoid_final_days=self.var_avoid.get(),
-            mu_mode=self.var_mu_mode.get(),
-            mu_custom=self.var_mu_custom.get(),
-        )
+    @staticmethod
+    def _option_code(option_type: str) -> str:
+        return {"call": "C", "put": "P"}.get(option_type.lower(), option_type.upper())
 
-    def _collect_config_batch_common(self) -> SimConfig:
-        # shared settings across all strikes in the batch
+    def _single_overrides(self) -> Dict[str, Any]:
+        symbol = self.var_symbol.get().strip().upper() or (self.data_settings.default_symbol or "GLD")
+        expiration = self.var_expiration.get().strip() or None
+        option_type = self.var_option_type.get().strip().lower()
+        return {
+            "symbol": symbol,
+            "option_type": option_type,
+            "expiration": expiration,
+            "annual_trading_days": self.var_annual.get(),
+            "risk_free_rate": self.var_rfr.get(),
+            "iv_fixed": self.var_iv_fixed.get(),
+            "iv_min": self.var_iv_min.get(),
+            "iv_max": self.var_iv_max.get(),
+            "num_trials": self.var_trials.get(),
+            "seed": self.var_seed.get(),
+            "commission_per_side": self.var_comm.get(),
+            "target_profit": self.var_target.get(),
+            "stop_option_price": self.var_stop.get(),
+            "avoid_final_days": self.var_avoid.get(),
+            "mu_mode": self.var_mu_mode.get(),
+            "mu_custom": self.var_mu_custom.get(),
+        }
+
+    def _batch_overrides(self) -> Dict[str, Any]:
+        symbol = self.b_symbol.get().strip().upper() or (self.data_settings.default_symbol or "GLD")
+        expiration = self.b_expiration.get().strip() or None
+        option_type = self.b_option_type.get().strip().lower()
+        return {
+            "symbol": symbol,
+            "option_type": option_type,
+            "expiration": expiration,
+            "annual_trading_days": self.b_annual.get(),
+            "risk_free_rate": self.b_rfr.get(),
+            "iv_fixed": self.b_iv_fixed.get(),
+            "iv_min": self.b_iv_min.get(),
+            "iv_max": self.b_iv_max.get(),
+            "num_trials": self.b_trials.get(),
+            "seed": self.b_seed.get(),
+            "commission_per_side": self.b_comm.get(),
+            "target_profit": self.b_target.get(),
+            "stop_option_price": self.b_stop.get(),
+            "avoid_final_days": self.b_avoid.get(),
+            "mu_mode": self.b_mu_mode.get(),
+            "mu_custom": self.b_mu_custom.get(),
+        }
+
+    def _build_config_from_contract(self, contract: pd.Series, overrides: Dict[str, Any]) -> SimConfig:
+        inputs = self._extract_contract_inputs(contract)
+        strike = inputs.get("strike")
+        entry = inputs.get("entry")
+        dte = inputs.get("dte")
+        spot = inputs.get("spot")
+        iv = inputs.get("iv")
+
+        if strike is None or entry is None or dte is None or spot is None:
+            raise ValueError("Contract is missing required pricing inputs from the live chain.")
+
+        iv_value = iv if iv is not None and iv > 0 else overrides.get("iv_fixed")
+        if iv_value is None or iv_value <= 0:
+            raise ValueError("Implied volatility unavailable; wait for chain data or adjust overrides.")
+
+        symbol = (overrides.get("symbol") or inputs.get("symbol") or "").upper()
+        option_type = (inputs.get("option_type") or overrides.get("option_type", "call")).lower()
+        expiration = inputs.get("expiration") or overrides.get("expiration")
+
         return SimConfig(
-            spot=self.b_spot.get(),
-            dte_calendar=self.b_dte.get(),
-            annual_trading_days=self.b_annual.get(),
-            risk_free_rate=self.b_rfr.get(),
-            iv_mode=self.b_iv_mode.get(),
-            iv_fixed=self.b_iv_fixed.get(),
-            iv_min=self.b_iv_min.get(),
-            iv_max=self.b_iv_max.get(),
-            num_trials=self.b_trials.get(),
-            seed=self.b_seed.get(),
-            entry_price=self.b_entry.get(),
-            commission_per_side=self.b_comm.get(),
-            target_profit=self.b_target.get(),
-            stop_option_price=self.b_stop.get(),
-            avoid_final_days=self.b_avoid.get(),
-            mu_mode=self.b_mu_mode.get(),
-            mu_custom=self.b_mu_custom.get(),
+            symbol=symbol,
+            option_type=option_type,
+            expiration=expiration,
+            contract_multiplier=100,
+            data_provider=self.data_settings,
+            spot=float(spot),
+            strike=float(strike),
+            dte_calendar=int(dte),
+            annual_trading_days=int(overrides["annual_trading_days"]),
+            risk_free_rate=float(overrides["risk_free_rate"]),
+            iv_mode="fixed",
+            iv_fixed=float(iv_value),
+            iv_min=float(overrides.get("iv_min", iv_value)),
+            iv_max=float(overrides.get("iv_max", iv_value)),
+            num_trials=int(overrides["num_trials"]),
+            seed=int(overrides["seed"]),
+            entry_price=float(entry),
+            commission_per_side=float(overrides["commission_per_side"]),
+            target_profit=float(overrides["target_profit"]),
+            stop_option_price=float(overrides["stop_option_price"]),
+            avoid_final_days=int(overrides["avoid_final_days"]),
+            mu_mode=overrides["mu_mode"],
+            mu_custom=float(overrides["mu_custom"]),
         )
 
     # ======= Actions =======
     def _run_single(self):
+        if self._selected_contract is None:
+            messagebox.showinfo(
+                "Run simulation",
+                "Double-click a contract or use Simulate Trade to select one before running.",
+            )
+            return
+
         try:
-            cfg = self._collect_config_single()
-        except Exception as e:
-            messagebox.showerror("Input error", f"Could not read inputs:\n{e}")
+            overrides = self._single_overrides()
+            cfg = self._build_config_from_contract(self._selected_contract, overrides)
+        except ValueError as exc:
+            messagebox.showerror("Simulation error", str(exc))
+            return
+        except Exception as exc:  # noqa: BLE001
+            messagebox.showerror("Simulation error", f"Could not prepare simulation:\n{exc}")
             return
 
         summary, details = simulate(cfg)
         os.makedirs("out", exist_ok=True)
         stamp = time.strftime("%Y%m%d_%H%M%S")
-        tag = f"GLD_{int(cfg.strike)}C_{cfg.dte_calendar}DTE_tr{cfg.num_trials}_{stamp}"
+        code = self._option_code(cfg.option_type)
+        tag = f"{cfg.symbol}_{int(cfg.strike)}{code}_{cfg.dte_calendar}DTE_tr{cfg.num_trials}_{stamp}"
         summary.to_csv(os.path.join("out", f"{tag}_summary.csv"), index=False)
         details.to_csv(os.path.join("out", f"{tag}_details.csv"), index=False)
 
@@ -295,30 +1065,63 @@ class SimUI(tk.Tk):
             messagebox.showerror("Input error", f"Bad strikes list:\n{e}")
             return
 
-        base = self._collect_config_batch_common()
+        if self._latest_chain is None or self._latest_chain.empty:
+            messagebox.showinfo("Batch simulation", "Stream an option chain before running a batch.")
+            return
+
+        overrides = self._batch_overrides()
         os.makedirs("out", exist_ok=True)
 
-        results = []  # list of (strike, summary_df, details_df)
+        results = []  # list of result dicts
         stamp = time.strftime("%Y%m%d_%H%M%S")
 
         for k in strikes:
-            cfg = SimConfig(**{**base.__dict__, "strike": k})
+            contract = self._find_contract(
+                symbol=overrides["symbol"],
+                option_type=overrides["option_type"],
+                strike=k,
+                expiration=overrides.get("expiration"),
+            )
+            if contract is None:
+                messagebox.showerror(
+                    "Batch simulation",
+                    f"No live chain data for strike {k:.2f} {overrides['option_type']}.",
+                )
+                return
+
+            try:
+                cfg = self._build_config_from_contract(contract, overrides)
+            except ValueError as exc:
+                messagebox.showerror("Batch simulation", str(exc))
+                return
+
             summary, details = simulate(cfg)
 
-            tag = f"GLD_{int(k)}C_{cfg.dte_calendar}DTE_tr{cfg.num_trials}_{stamp}"
+            code = self._option_code(cfg.option_type)
+            tag = f"{cfg.symbol}_{int(k)}{code}_{cfg.dte_calendar}DTE_tr{cfg.num_trials}_{stamp}"
             summary.to_csv(os.path.join("out", f"{tag}_summary.csv"), index=False)
             details.to_csv(os.path.join("out", f"{tag}_details.csv"), index=False)
 
             s_copy = summary.copy()
             s_copy.insert(0, "Strike", k)
-            results.append((k, s_copy, details))
+            s_copy.insert(1, "Option Type", cfg.option_type)
+            results.append({
+                "strike": k,
+                "option_type": cfg.option_type,
+                "summary": s_copy,
+                "details": details,
+            })
 
         # Save combined batch summary
-        combo = pd.concat([r[1] for r in results], ignore_index=True)
+        combo = pd.concat([r["summary"] for r in results], ignore_index=True)
         combo.to_csv(os.path.join("out", f"batch_summary_{stamp}.csv"), index=False)
 
         # Show batch results window (overlaid charts)
         self._show_results_window_batch(results, stamp)
+
+    def destroy(self):
+        self._stop_chain_stream()
+        super().destroy()
 
     # ======= Result windows =======
     def _show_results_window_single(self, details: pd.DataFrame, tag: str):
@@ -357,10 +1160,7 @@ class SimUI(tk.Tk):
         ttk.Button(win, text="Close", command=win.destroy).pack(side="bottom", pady=PAD)
 
     def _show_results_window_batch(self, results, stamp_tag: str):
-        """
-        results: list of (strike, summary_df, details_df)
-        Draw overlaid histograms with distinct colors + legend.
-        """
+        """Draw overlaid histograms with distinct colors + legend."""
         win = tk.Toplevel(self)
         win.title(f"Batch Results — {stamp_tag}")
         win.geometry("1200x780")
@@ -379,13 +1179,16 @@ class SimUI(tk.Tk):
         fig1 = plt.Figure(figsize=(6.8, 5.0), dpi=100)
         ax1 = fig1.add_subplot(111)
 
-        for idx, (k, _summary, details) in enumerate(results):
+        for idx, result in enumerate(results):
+            k = result["strike"]
+            option_type = result["option_type"]
+            details = result["details"]
             color = palette[idx % len(palette)]
             ax1.hist(
                 details["final_pl"],
                 bins=70,
                 alpha=0.35,
-                label=f"{int(k)}C",
+                label=f"{int(k)}{self._option_code(option_type)}",
                 color=color
             )
 
@@ -393,7 +1196,7 @@ class SimUI(tk.Tk):
         ax1.set_xlabel("P&L per contract ($)")
         ax1.set_ylabel("Frequency")
         ax1.grid(True, alpha=0.3)
-        ax1.legend(title="Strike")
+        ax1.legend(title="Strike/Type")
 
         canvas1 = FigureCanvasTkAgg(fig1, master=container)
         canvas1.draw()
@@ -403,14 +1206,17 @@ class SimUI(tk.Tk):
         fig2 = plt.Figure(figsize=(6.8, 5.0), dpi=100)
         ax2 = fig2.add_subplot(111)
 
-        for idx, (k, _summary, details) in enumerate(results):
+        for idx, result in enumerate(results):
+            k = result["strike"]
+            option_type = result["option_type"]
+            details = result["details"]
             color = palette[idx % len(palette)]
             if details["hit_target"].any():
                 ax2.hist(
                     details.loc[details["hit_target"], "hit_day"],
                     bins=range(1, 60),
                     alpha=0.45,
-                    label=f"{int(k)}C",
+                    label=f"{int(k)}{self._option_code(option_type)}",
                     color=color
                 )
 
@@ -418,7 +1224,7 @@ class SimUI(tk.Tk):
         ax2.set_xlabel("Trading day of exit")
         ax2.set_ylabel("Count")
         ax2.grid(True, alpha=0.3)
-        ax2.legend(title="Strike")
+        ax2.legend(title="Strike/Type")
 
         canvas2 = FigureCanvasTkAgg(fig2, master=container)
         canvas2.draw()


### PR DESCRIPTION
## Summary
- add richer Schwab data parsing that computes days-to-expiration, exposes mark/trade price fields, and tracks contract symbols alongside underlying metadata
- replace the tree view with an interactive call/put matrix that highlights selections, displays required P/L and greek columns, and updates a new status banner
- wire single and batch simulations to live chain selections, auto-populating form fields, computing DTE fallbacks, and blocking runs when pricing data is missing

## Testing
- python -m compileall gld_mc

------
https://chatgpt.com/codex/tasks/task_e_68e45a0dc6588331a6d75f2b23a42288